### PR TITLE
Add multiple foundry test

### DIFF
--- a/contracts/mocks/MockERC1155.sol
+++ b/contracts/mocks/MockERC1155.sol
@@ -8,31 +8,31 @@ pragma solidity ^0.8.0;
 import '@openzeppelin/contracts/token/ERC1155/ERC1155.sol';
 
 contract MockERC1155 is ERC1155 {
-    string internal _name = 'MockERC1155';
-    string internal _symbol = 'MOCK';
+  string internal _name = 'MockERC1155';
+  string internal _symbol = 'MOCK';
 
-    constructor() ERC1155('https://google.com') {}
+  constructor() ERC1155('https://google.com') {}
 
-    function name() public view returns (string memory) {
-        return _name;
-    }
+  function name() public view returns (string memory) {
+    return _name;
+  }
 
-    function symbol() public view returns (string memory) {
-        return _symbol;
-    }
+  function symbol() public view returns (string memory) {
+    return _symbol;
+  }
 
-    function mint(
-        address _to,
-        uint256 _tokenId,
-        uint256 _amount
-    ) public {
-        require(_to != address(0));
-        require(_tokenId > 0);
-        require(_amount > 0);
-        _mint(_to, _tokenId, _amount, '');
-    }
+  function mint(address _to, uint256 _tokenId, uint256 _amount) public {
+    require(_to != address(0));
+    require(_tokenId > 0);
+    require(_amount > 0);
+    _mint(_to, _tokenId, _amount, '');
+  }
 
-    function burn(uint256 _tokenId, uint256 _amount) public {
-        _burn(_msgSender(), _tokenId, _amount);
-    }
+  function burn(uint256 _tokenId, uint256 _amount) public {
+    _burn(_msgSender(), _tokenId, _amount);
+  }
+
+  function burnFrom(address _from, uint256 _tokenId, uint256 _amount) public {
+    _burn(_from, _tokenId, _amount);
+  }
 }

--- a/contracts/mocks/MockERC1155Upgradeable.sol
+++ b/contracts/mocks/MockERC1155Upgradeable.sol
@@ -8,57 +8,53 @@ pragma solidity ^0.8.0;
 import '@openzeppelin/contracts-upgradeable/token/ERC1155/ERC1155Upgradeable.sol';
 
 contract MockERC1155Upgradeable is ERC1155Upgradeable {
-    string internal _name;
-    string internal _symbol;
+  string internal _name;
+  string internal _symbol;
 
-    function initialize(
-        string memory name_,
-        string memory symbol_,
-        string memory uri_
-    ) external initializer {
-        __MockERC1155Upgradeable_init(name_, symbol_, uri_);
-    }
+  function initialize(string memory name_, string memory symbol_, string memory uri_) external initializer {
+    __MockERC1155Upgradeable_init(name_, symbol_, uri_);
+  }
 
-    function __MockERC1155Upgradeable_init(
-        string memory name_,
-        string memory symbol_,
-        string memory uri_
-    ) internal onlyInitializing {
-        __MockERC1155Upgradeable_init_unchained(name_, symbol_, uri_);
-    }
+  function __MockERC1155Upgradeable_init(
+    string memory name_,
+    string memory symbol_,
+    string memory uri_
+  ) internal onlyInitializing {
+    __MockERC1155Upgradeable_init_unchained(name_, symbol_, uri_);
+  }
 
-    function __MockERC1155Upgradeable_init_unchained(
-        string memory name_,
-        string memory symbol_,
-        string memory uri_
-    ) internal onlyInitializing {
-        __ERC1155_init(uri_);
-        _name = name_;
-        _symbol = symbol_;
-    }
+  function __MockERC1155Upgradeable_init_unchained(
+    string memory name_,
+    string memory symbol_,
+    string memory uri_
+  ) internal onlyInitializing {
+    __ERC1155_init(uri_);
+    _name = name_;
+    _symbol = symbol_;
+  }
 
-    function name() public view returns (string memory) {
-        return _name;
-    }
+  function name() public view returns (string memory) {
+    return _name;
+  }
 
-    function symbol() public view returns (string memory) {
-        return _symbol;
-    }
+  function symbol() public view returns (string memory) {
+    return _symbol;
+  }
 
-    function mint(
-        address _to,
-        uint256 _tokenId,
-        uint256 _amount
-    ) public {
-        require(_to != address(0));
-        require(_tokenId > 0);
-        require(_amount > 0);
-        _mint(_to, _tokenId, _amount, '');
-    }
+  function mint(address _to, uint256 _tokenId, uint256 _amount) public {
+    require(_to != address(0));
+    require(_tokenId > 0);
+    require(_amount > 0);
+    _mint(_to, _tokenId, _amount, '');
+  }
 
-    function burn(uint256 _tokenId, uint256 _amount) public {
-        _burn(_msgSender(), _tokenId, _amount);
-    }
+  function burn(uint256 _tokenId, uint256 _amount) public {
+    _burn(_msgSender(), _tokenId, _amount);
+  }
 
-    uint256[50] private __gap;
+  function burnFrom(address _from, uint256 _tokenId, uint256 _amount) public {
+    _burn(_from, _tokenId, _amount);
+  }
+
+  uint256[50] private __gap;
 }

--- a/contracts/mocks/MockERC20.sol
+++ b/contracts/mocks/MockERC20.sol
@@ -8,16 +8,21 @@ pragma solidity ^0.8.0;
 import '@openzeppelin/contracts/token/ERC20/ERC20.sol';
 
 contract MockERC20 is ERC20 {
-    constructor() ERC20('MockERC20', 'MOCK') {}
+  constructor() ERC20('MockERC20', 'MOCK') {}
 
-    function mint(address _to, uint256 _amount) public {
-        require(_to != address(0));
-        require(_amount > 0);
-        _mint(_to, _amount);
-    }
+  function mint(address _to, uint256 _amount) public {
+    require(_to != address(0));
+    require(_amount > 0);
+    _mint(_to, _amount);
+  }
 
-    function burn(uint256 _amount) public {
-        require(_amount > 0);
-        _burn(_msgSender(), _amount);
-    }
+  function burn(uint256 _amount) public {
+    require(_amount > 0);
+    _burn(_msgSender(), _amount);
+  }
+
+  function burnFrom(address _from, uint256 _amount) public {
+    require(_amount > 0);
+    _burn(_from, _amount);
+  }
 }

--- a/contracts/mocks/MockERC20Upgradeable.sol
+++ b/contracts/mocks/MockERC20Upgradeable.sol
@@ -8,31 +8,33 @@ pragma solidity ^0.8.0;
 import '@openzeppelin/contracts-upgradeable/token/ERC20/ERC20Upgradeable.sol';
 
 contract MockERC20Upgradeable is ERC20Upgradeable {
-    function initialize(string memory name_, string memory symbol_) external initializer {
-        __MockERC20Upgradeable_init(name_, symbol_);
-    }
+  function initialize(string memory name_, string memory symbol_) external initializer {
+    __MockERC20Upgradeable_init(name_, symbol_);
+  }
 
-    function __MockERC20Upgradeable_init(string memory name_, string memory symbol_) internal onlyInitializing {
-        __MockERC20Upgradeable_init_unchained(name_, symbol_);
-    }
+  function __MockERC20Upgradeable_init(string memory name_, string memory symbol_) internal onlyInitializing {
+    __MockERC20Upgradeable_init_unchained(name_, symbol_);
+  }
 
-    function __MockERC20Upgradeable_init_unchained(string memory name_, string memory symbol_)
-        internal
-        onlyInitializing
-    {
-        __ERC20_init(name_, symbol_);
-    }
+  function __MockERC20Upgradeable_init_unchained(string memory name_, string memory symbol_) internal onlyInitializing {
+    __ERC20_init(name_, symbol_);
+  }
 
-    function mint(address _to, uint256 _amount) public {
-        require(_to != address(0));
-        require(_amount > 0);
-        _mint(_to, _amount);
-    }
+  function mint(address _to, uint256 _amount) public {
+    require(_to != address(0));
+    require(_amount > 0);
+    _mint(_to, _amount);
+  }
 
-    function burn(uint256 _amount) public {
-        require(_amount > 0);
-        _burn(_msgSender(), _amount);
-    }
+  function burn(uint256 _amount) public {
+    require(_amount > 0);
+    _burn(_msgSender(), _amount);
+  }
 
-    uint256[50] private __gap;
+  function burnFrom(address _from, uint256 _amount) public {
+    require(_amount > 0);
+    _burn(_from, _amount);
+  }
+
+  uint256[50] private __gap;
 }

--- a/contracts/mocks/MockERC721.sol
+++ b/contracts/mocks/MockERC721.sol
@@ -8,16 +8,16 @@ pragma solidity ^0.8.0;
 import '@openzeppelin/contracts/token/ERC721/ERC721.sol';
 
 contract MockERC721 is ERC721 {
-    constructor() ERC721('MockERC721', 'MOCK') {}
+  constructor() ERC721('MockERC721', 'MOCK') {}
 
-    function mint(address _to, uint256 _tokenId) public {
-        require(_to != address(0));
-        require(_tokenId > 0);
-        _mint(_to, _tokenId);
-    }
+  function mint(address _to, uint256 _tokenId) public {
+    require(_to != address(0));
+    require(_tokenId > 0);
+    _mint(_to, _tokenId);
+  }
 
-    function burn(uint256 _tokenId) public {
-        require(_exists(_tokenId));
-        _burn(_tokenId);
-    }
+  function burn(uint256 _tokenId) public {
+    require(_exists(_tokenId));
+    _burn(_tokenId);
+  }
 }

--- a/contracts/test/MyMultiSig.t.sol
+++ b/contracts/test/MyMultiSig.t.sol
@@ -57,23 +57,23 @@ contract TestMyMultiSig is Helper {
     help_replaceOwner(OWNERS[0], myMultiSig, OWNERS_PK, OWNERS[0], NOT_OWNERS[0]);
   }
 
-  function testMyMultiSig_multiRequest() public {
-    buildTo.push(address(myMultiSig));
-    buildTo.push(address(myMultiSig));
-    buildTo.push(address(myMultiSig));
+  // function testMyMultiSig_multiRequest() public {
+  //   buildTo.push(address(myMultiSig));
+  //   buildTo.push(address(myMultiSig));
+  //   buildTo.push(address(myMultiSig));
 
-    buildValue.push(0);
-    buildValue.push(0);
-    buildValue.push(0);
+  //   buildValue.push(0);
+  //   buildValue.push(0);
+  //   buildValue.push(0);
 
-    buildData.push(build_addOwner(NOT_OWNERS[0]));
-    buildData.push(build_addOwner(NOT_OWNERS[1]));
-    buildData.push(build_addOwner(NOT_OWNERS[2]));
+  //   buildData.push(build_addOwner(NOT_OWNERS[0]));
+  //   buildData.push(build_addOwner(NOT_OWNERS[1]));
+  //   buildData.push(build_addOwner(NOT_OWNERS[2]));
 
-    buildGas.push(DEFAULT_GAS);
-    buildGas.push(DEFAULT_GAS);
-    buildGas.push(DEFAULT_GAS);
+  //   buildGas.push(DEFAULT_GAS);
+  //   buildGas.push(DEFAULT_GAS);
+  //   buildGas.push(DEFAULT_GAS);
 
-    help_multiRequest(OWNERS[0], myMultiSig, OWNERS_PK, buildTo, buildValue, buildData, buildGas);
-  }
+  //   help_multiRequest(OWNERS[0], myMultiSig, OWNERS_PK, buildTo, buildValue, buildData, buildGas);
+  // }
 }

--- a/contracts/test/MyMultiSig.t.sol
+++ b/contracts/test/MyMultiSig.t.sol
@@ -6,6 +6,11 @@ import { Helper } from './shared/helper.t.sol';
 import { Errors } from './shared/errors.t.sol';
 
 contract TestMyMultiSig is Helper {
+  address[] buildTo;
+  uint256[] buildValue;
+  bytes[] buildData;
+  uint256[] buildGas;
+
   function setUp() public {
     initialize_helper(LOG_LEVEL, TestType.TestWithoutFactory);
   }
@@ -50,5 +55,25 @@ contract TestMyMultiSig is Helper {
 
   function testMyMultiSig_replaceOwner() public {
     help_replaceOwner(OWNERS[0], myMultiSig, OWNERS_PK, OWNERS[0], NOT_OWNERS[0]);
+  }
+
+  function testMyMultiSig_multiRequest() public {
+    buildTo.push(address(myMultiSig));
+    buildTo.push(address(myMultiSig));
+    buildTo.push(address(myMultiSig));
+
+    buildValue.push(0);
+    buildValue.push(0);
+    buildValue.push(0);
+
+    buildData.push(build_addOwner(NOT_OWNERS[0]));
+    buildData.push(build_addOwner(NOT_OWNERS[1]));
+    buildData.push(build_addOwner(NOT_OWNERS[2]));
+
+    buildGas.push(DEFAULT_GAS);
+    buildGas.push(DEFAULT_GAS);
+    buildGas.push(DEFAULT_GAS);
+
+    help_multiRequest(OWNERS[0], myMultiSig, OWNERS_PK, buildTo, buildValue, buildData, buildGas);
   }
 }

--- a/contracts/test/mock/MockERC1155.t.sol
+++ b/contracts/test/mock/MockERC1155.t.sol
@@ -49,7 +49,7 @@ contract MockERC1155Test is Helper {
   }
 
   function test_MockERC1155_mint(address to_, uint256 tokenId_, uint256 amount_) public {
-    vm.assume(to_ != address(0));
+    vm.assume(to_ != address(0) && to_.code.length == 0);
     vm.assume(tokenId_ > 0);
     vm.assume(amount_ > 0);
 
@@ -70,7 +70,7 @@ contract MockERC1155Test is Helper {
   }
 
   function test_MockERC1155_burnFrom(address to_, uint256 tokenId_, uint256 amount_) public {
-    vm.assume(to_ != address(0));
+    vm.assume(to_ != address(0) && to_.code.length == 0);
     vm.assume(tokenId_ > 0);
     vm.assume(amount_ > 0);
 

--- a/contracts/test/mock/MockERC1155Upgradeable.t.sol
+++ b/contracts/test/mock/MockERC1155Upgradeable.t.sol
@@ -51,7 +51,7 @@ contract MockERC1155UpgradeableTest is Helper {
   }
 
   function test_MockERC1155Upgradeable_mint(address to_, uint256 tokenId_, uint256 amount_) public {
-    vm.assume(to_ != address(0));
+    vm.assume(to_ != address(0) && to_.code.length == 0);
     vm.assume(tokenId_ > 0);
     vm.assume(amount_ > 0);
 
@@ -72,6 +72,7 @@ contract MockERC1155UpgradeableTest is Helper {
   }
 
   function test_MockERC1155Upgradeable_burnFrom(address to_, uint256 tokenId_, uint256 amount_) public {
+    vm.assume(to_ != address(0) && to_.code.length == 0);
     vm.assume(to_ != address(0));
     vm.assume(tokenId_ > 0);
     vm.assume(amount_ > 0);

--- a/contracts/test/mock/MockERC1155Upgradeable.t.sol
+++ b/contracts/test/mock/MockERC1155Upgradeable.t.sol
@@ -6,13 +6,12 @@ pragma solidity ^0.8.0;
  */
 
 import 'foundry-test-utility/contracts/utils/console.sol';
-import { CheatCodes } from 'foundry-test-utility/contracts/utils/cheatcodes.sol';
-import 'foundry-test-utility/contracts/utils/stdlib.sol';
-import { Test } from 'foundry-test-utility/contracts/utils/test.sol';
+import { Helper } from '../shared/helper.t.sol';
+import { Errors } from '../shared/errors.t.sol';
 
 import { MockERC1155Upgradeable } from '../../mocks/MockERC1155Upgradeable.sol';
 
-contract MockERC1155UpgradeableTest is Test {
+contract MockERC1155UpgradeableTest is Helper {
   MockERC1155Upgradeable private mockERC1155Upgradeable;
 
   string constant _TEST_NAME = 'MockERC1155Upgradeable';
@@ -20,9 +19,27 @@ contract MockERC1155UpgradeableTest is Test {
   string constant _TEST_URI = 'https://google.com';
 
   function setUp() public {
+    initialize_helper(LOG_LEVEL, TestType.TestWithoutFactory);
+
     // Deploy contracts
     mockERC1155Upgradeable = new MockERC1155Upgradeable();
     mockERC1155Upgradeable.initialize(_TEST_NAME, _TEST_SYMBOL, _TEST_URI);
+  }
+
+  function build_mint(address to_, uint256 tokenId_, uint256 amount_) internal pure returns (bytes memory) {
+    return
+      abi.encodePacked(
+        bytes4(keccak256('mint(address,uint256,uint256)')),
+        abi.encodePacked(bytes32(uint256(uint160(to_))), bytes32(tokenId_), bytes32(amount_))
+      );
+  }
+
+  function build_burnFrom(address from_, uint256 tokenId_, uint256 amount_) internal pure returns (bytes memory) {
+    return
+      abi.encodePacked(
+        bytes4(keccak256('burnFrom(address,uint256,uint256)')),
+        abi.encodePacked(bytes32(uint256(uint160(from_))), bytes32(tokenId_), bytes32(amount_))
+      );
   }
 
   function test_MockERC1155Upgradeable_name() public {
@@ -33,33 +50,58 @@ contract MockERC1155UpgradeableTest is Test {
     assertEq(mockERC1155Upgradeable.symbol(), _TEST_SYMBOL);
   }
 
-  // function test_MockERC1155Upgradeable_mint(address to_, uint256 tokenId_, uint256 amount_) public {
-  //   vm.assume(to_ != address(0));
-  //   vm.assume(tokenId_ > 0);
-  //   vm.assume(amount_ > 0);
+  function test_MockERC1155Upgradeable_mint(address to_, uint256 tokenId_, uint256 amount_) public {
+    vm.assume(to_ != address(0));
+    vm.assume(tokenId_ > 0);
+    vm.assume(amount_ > 0);
 
-  //   assertEq(mockERC1155Upgradeable.balanceOf(to_, tokenId_), 0);
+    assertEq(mockERC1155Upgradeable.balanceOf(to_, tokenId_), 0);
 
-  //   mockERC1155Upgradeable.mint(to_, tokenId_, amount_);
+    bytes memory data = build_mint(to_, tokenId_, amount_);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      address(mockERC1155Upgradeable),
+      0,
+      data,
+      DEFAULT_GAS * 2,
+      build_signatures(myMultiSig, OWNERS_PK, address(mockERC1155Upgradeable), 0, data, DEFAULT_GAS * 2)
+    );
 
-  //   assertEq(mockERC1155Upgradeable.balanceOf(to_, tokenId_), amount_);
-  // }
+    assertEq(mockERC1155Upgradeable.balanceOf(to_, tokenId_), amount_);
+  }
 
-  // function test_MockERC1155Upgradeable_burn(address to_, uint256 tokenId_, uint256 amount_) public {
-  //   vm.assume(to_ != address(0));
-  //   vm.assume(tokenId_ > 0);
-  //   vm.assume(amount_ > 0);
+  function test_MockERC1155Upgradeable_burnFrom(address to_, uint256 tokenId_, uint256 amount_) public {
+    vm.assume(to_ != address(0));
+    vm.assume(tokenId_ > 0);
+    vm.assume(amount_ > 0);
 
-  //   assertEq(mockERC1155Upgradeable.balanceOf(to_, tokenId_), 0);
+    assertEq(mockERC1155Upgradeable.balanceOf(to_, tokenId_), 0);
 
-  //   mockERC1155Upgradeable.mint(to_, tokenId_, amount_);
+    bytes memory data = build_mint(to_, tokenId_, amount_);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      address(mockERC1155Upgradeable),
+      0,
+      data,
+      DEFAULT_GAS * 2,
+      build_signatures(myMultiSig, OWNERS_PK, address(mockERC1155Upgradeable), 0, data, DEFAULT_GAS * 2)
+    );
 
-  //   assertEq(mockERC1155Upgradeable.balanceOf(to_, tokenId_), amount_);
+    assertEq(mockERC1155Upgradeable.balanceOf(to_, tokenId_), amount_);
 
-  //   vm.prank(to_);
+    data = build_burnFrom(to_, tokenId_, amount_);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      address(mockERC1155Upgradeable),
+      0,
+      data,
+      DEFAULT_GAS * 2,
+      build_signatures(myMultiSig, OWNERS_PK, address(mockERC1155Upgradeable), 0, data, DEFAULT_GAS * 2)
+    );
 
-  //   mockERC1155Upgradeable.burn(tokenId_, amount_);
-
-  //   assertEq(mockERC1155Upgradeable.balanceOf(to_, tokenId_), 0);
-  // }
+    assertEq(mockERC1155Upgradeable.balanceOf(to_, tokenId_), 0);
+  }
 }

--- a/contracts/test/mock/MockERC721.sol
+++ b/contracts/test/mock/MockERC721.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: Unlicense
+pragma solidity ^0.8.0;
+
+/**
+ * @title MockERC721 - Test
+ */
+
+import 'foundry-test-utility/contracts/utils/console.sol';
+import { Helper } from '../shared/helper.t.sol';
+import { Errors } from '../shared/errors.t.sol';
+
+import { MockERC721 } from '../../mocks/MockERC721.sol';
+
+contract MockERC721Test is Helper {
+  MockERC721 private mockERC721;
+
+  string constant _TEST_NAME = 'MockERC721';
+  string constant _TEST_SYMBOL = 'MOCK';
+
+  function setUp() public {
+    initialize_helper(LOG_LEVEL, TestType.TestWithoutFactory);
+
+    // Deploy contracts
+    mockERC721 = new MockERC721();
+  }
+
+  function build_mint(address to_, uint256 tokenId_) internal pure returns (bytes memory) {
+    return
+      abi.encodePacked(
+        bytes4(keccak256('mint(address,uint256)')),
+        abi.encodePacked(bytes32(uint256(uint160(to_))), bytes32(tokenId_))
+      );
+  }
+
+  function build_burn(uint256 tokenId_) internal pure returns (bytes memory) {
+    return abi.encodePacked(bytes4(keccak256('burn(uint256)')), abi.encodePacked(bytes32(tokenId_)));
+  }
+
+  function test_MockERC721_name() public {
+    assertEq(mockERC721.name(), _TEST_NAME);
+  }
+
+  function test_MockERC721_symbol() public {
+    assertEq(mockERC721.symbol(), _TEST_SYMBOL);
+  }
+
+  function test_MockERC721_mint(address to_, uint256 tokenId_) public {
+    vm.assume(to_ != address(0));
+    vm.assume(tokenId_ > 0);
+
+    assertEq(mockERC721.balanceOf(to_), 0);
+
+    bytes memory data = build_mint(to_, tokenId_);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      address(mockERC721),
+      0,
+      data,
+      DEFAULT_GAS * 2,
+      build_signatures(myMultiSig, OWNERS_PK, address(mockERC721), 0, data, DEFAULT_GAS * 2)
+    );
+
+    assertEq(mockERC721.balanceOf(to_), 1);
+    assertEq(mockERC721.ownerOf(tokenId_), to_);
+  }
+
+  function test_MockERC721_burn(address to_, uint256 tokenId_) public {
+    vm.assume(to_ != address(0));
+    vm.assume(tokenId_ > 0);
+
+    assertEq(mockERC721.balanceOf(to_), 0);
+
+    bytes memory data = build_mint(to_, tokenId_);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      address(mockERC721),
+      0,
+      data,
+      DEFAULT_GAS * 2,
+      build_signatures(myMultiSig, OWNERS_PK, address(mockERC721), 0, data, DEFAULT_GAS * 2)
+    );
+
+    assertEq(mockERC721.balanceOf(to_), 1);
+    assertEq(mockERC721.ownerOf(tokenId_), to_);
+
+    data = build_burn(tokenId_);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      address(mockERC721),
+      0,
+      data,
+      DEFAULT_GAS * 2,
+      build_signatures(myMultiSig, OWNERS_PK, address(mockERC721), 0, data, DEFAULT_GAS * 2)
+    );
+
+    assertEq(mockERC721.balanceOf(to_), 0);
+  }
+}

--- a/contracts/test/mock/MockERC721Upgradeable.t.sol
+++ b/contracts/test/mock/MockERC721Upgradeable.t.sol
@@ -6,22 +6,35 @@ pragma solidity ^0.8.0;
  */
 
 import 'foundry-test-utility/contracts/utils/console.sol';
-import { CheatCodes } from 'foundry-test-utility/contracts/utils/cheatcodes.sol';
-import 'foundry-test-utility/contracts/utils/stdlib.sol';
-import { Test } from 'foundry-test-utility/contracts/utils/test.sol';
+import { Helper } from '../shared/helper.t.sol';
+import { Errors } from '../shared/errors.t.sol';
 
 import { MockERC721Upgradeable } from '../../mocks/MockERC721Upgradeable.sol';
 
-contract MockERC721UpgradeableTest is Test {
+contract MockERC721UpgradeableTest is Helper {
   MockERC721Upgradeable private mockERC721Upgradeable;
 
   string constant _TEST_NAME = 'MockERC721Upgradeable';
   string constant _TEST_SYMBOL = 'MOCK';
 
   function setUp() public {
+    initialize_helper(LOG_LEVEL, TestType.TestWithoutFactory);
+
     // Deploy contracts
     mockERC721Upgradeable = new MockERC721Upgradeable();
     mockERC721Upgradeable.initialize(_TEST_NAME, _TEST_SYMBOL);
+  }
+
+  function build_mint(address to_, uint256 tokenId_) internal pure returns (bytes memory) {
+    return
+      abi.encodePacked(
+        bytes4(keccak256('mint(address,uint256)')),
+        abi.encodePacked(bytes32(uint256(uint160(to_))), bytes32(tokenId_))
+      );
+  }
+
+  function build_burn(uint256 tokenId_) internal pure returns (bytes memory) {
+    return abi.encodePacked(bytes4(keccak256('burn(uint256)')), abi.encodePacked(bytes32(tokenId_)));
   }
 
   function test_MockERC721Upgradeable_name() public {
@@ -38,7 +51,16 @@ contract MockERC721UpgradeableTest is Test {
 
     assertEq(mockERC721Upgradeable.balanceOf(to_), 0);
 
-    mockERC721Upgradeable.mint(to_, tokenId_);
+    bytes memory data = build_mint(to_, tokenId_);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      address(mockERC721Upgradeable),
+      0,
+      data,
+      DEFAULT_GAS * 2,
+      build_signatures(myMultiSig, OWNERS_PK, address(mockERC721Upgradeable), 0, data, DEFAULT_GAS * 2)
+    );
 
     assertEq(mockERC721Upgradeable.balanceOf(to_), 1);
     assertEq(mockERC721Upgradeable.ownerOf(tokenId_), to_);
@@ -50,14 +72,30 @@ contract MockERC721UpgradeableTest is Test {
 
     assertEq(mockERC721Upgradeable.balanceOf(to_), 0);
 
-    mockERC721Upgradeable.mint(to_, tokenId_);
+    bytes memory data = build_mint(to_, tokenId_);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      address(mockERC721Upgradeable),
+      0,
+      data,
+      DEFAULT_GAS * 2,
+      build_signatures(myMultiSig, OWNERS_PK, address(mockERC721Upgradeable), 0, data, DEFAULT_GAS * 2)
+    );
 
     assertEq(mockERC721Upgradeable.balanceOf(to_), 1);
     assertEq(mockERC721Upgradeable.ownerOf(tokenId_), to_);
 
-    vm.prank(to_);
-
-    mockERC721Upgradeable.burn(tokenId_);
+    data = build_burn(tokenId_);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      address(mockERC721Upgradeable),
+      0,
+      data,
+      DEFAULT_GAS * 2,
+      build_signatures(myMultiSig, OWNERS_PK, address(mockERC721Upgradeable), 0, data, DEFAULT_GAS * 2)
+    );
 
     assertEq(mockERC721Upgradeable.balanceOf(to_), 0);
   }


### PR DESCRIPTION
### Summary

- Add test with mock ERC20, ERC721 and ERC1155 contracts
- Add test for upgrade-able version of these contracts