### PR TITLE
fix: distinct custom errors + TxFailure reason for exec failures

### DIFF
--- a/contracts/MyMultiSig.sol
+++ b/contracts/MyMultiSig.sol
@@ -29,25 +29,45 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     uint256 txnGas,
     uint256 txnNonce
   );
-  event TransactionFailed(
+  /// @notice Emitted when a transaction is executed but the low-level call to
+  ///         `to` returned `false`. `reason` carries the raw return data of the
+  ///         failed call so front-ends can decode the target's revert reason and
+  ///         distinguish an on-chain revert from a signature or gas failure
+  ///         (those revert the whole `execTransaction` with a distinct custom error).
+  event TxFailure(
     address indexed sender,
     address indexed to,
     uint256 indexed value,
     bytes data,
     uint256 txnGas,
-    uint256 txnNonce
+    uint256 txnNonce,
+    bytes reason
   );
   event ContractEndOfLife(uint256 indexed txNonceLefts);
 
+  error OnlyThisContract();
+  error TooManyOwners();
+  error InvalidSignatures();
+  error InvalidOwner();
+  error OwnerAlreadySigned();
+  error NotEnoughGas();
+  error OwnerAlreadyExists();
+  error CannotRemoveOwnerBelowThreshold();
+  error ThresholdMustBeGreaterThanZero();
+  error ThresholdMustBeLessOrEqualToOwnerCount();
+  error OldOwnerMustBeOwner();
+  error NewOwnerMustNotBeOwner();
+  error NewOwnerMustNotBeZero();
+
   modifier onlyThis() {
-    require(msg.sender == address(this), 'MyMultiSig: only this contract can call this function');
+    if (msg.sender != address(this)) revert OnlyThisContract();
     _;
   }
 
   constructor(string memory name_, address[] memory owners_, uint16 threshold_) EIP712(name_, version()) {
     _name = name_;
     uint256 length = owners_.length;
-    require(length <= 2 ** 16 - 1, 'MyMultiSig: cannot add owner above 2^16 - 1');
+    if (length > 2 ** 16 - 1) revert TooManyOwners();
     for (uint256 i = 0; i < length; ) {
       _addOwner(owners_[i]);
       unchecked {
@@ -127,15 +147,21 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     uint256 txnNonce,
     bytes memory signatures
   ) internal virtual returns (bool success) {
-    require(_validateSignature(to, value, data, txnGas, txnNonce, signatures), 'MyMultiSig: invalid signatures');
+    if (!_validateSignature(to, value, data, txnGas, txnNonce, signatures)) revert InvalidSignatures();
     _txnNonce++;
     uint256 gasBefore = gasleft();
+    bytes memory returnData;
     assembly {
       success := call(txnGas, to, value, add(data, 0x20), mload(data), 0, 0)
+      let size := returndatasize()
+      returnData := mload(0x40)
+      mstore(returnData, size)
+      returndatacopy(add(returnData, 0x20), 0, size)
+      mstore(0x40, add(add(returnData, 0x20), and(add(size, 0x1f), not(0x1f))))
     }
-    require(gasBefore - gasleft() < txnGas, 'MyMultiSig: not enough gas');
+    if (gasBefore - gasleft() >= txnGas) revert NotEnoughGas();
     if (success) emit TransactionExecuted(msg.sender, to, value, data, txnGas, txnNonce);
-    else emit TransactionFailed(msg.sender, to, value, data, txnGas, txnNonce);
+    else emit TxFailure(msg.sender, to, value, data, txnGas, txnNonce, returnData);
   }
 
   /// @notice Prepare multiple transactions
@@ -237,8 +263,8 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     unchecked {
       currentOwner = _getCurrentOwner(txHash, signatures, currentIndex);
       uint256 currentOwnerNonce = uint256(uint96(txnNonce)) + uint256(uint160(currentOwner) << 96);
-      require(_owners[currentOwner], 'MyMultiSig: invalid owner');
-      require(!_ownerNonceSigned[currentOwnerNonce], 'MyMultiSig: owner already signed');
+      if (!_owners[currentOwner]) revert InvalidOwner();
+      if (_ownerNonceSigned[currentOwnerNonce]) revert OwnerAlreadySigned();
       _ownerNonceSigned[currentOwnerNonce] = true;
     }
   }
@@ -277,7 +303,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   /// @param owner The address to be added as an owner.
   /// @dev This function can only be called inside a multisig transaction.
   function _addOwner(address owner) internal virtual {
-    require(!_owners[owner], 'MyMultiSig: owner already exists');
+    if (_owners[owner]) revert OwnerAlreadyExists();
     _owners[owner] = true;
     ++_ownerCount;
   }
@@ -286,7 +312,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   /// @param owner The address to be added as an owner.
   /// @dev This function can only be called inside a multisig transaction.
   function addOwner(address owner) public virtual onlyThis {
-    require(_ownerCount < 2 ** 16 - 1, 'MyMultiSig: cannot add owner above 2^16 - 1');
+    if (_ownerCount >= 2 ** 16 - 1) revert TooManyOwners();
     _addOwner(owner);
   }
 
@@ -295,7 +321,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   /// @dev This function can only be called inside a multisig transaction.
 
   function _removeOwner(address owner) internal virtual {
-    if (_ownerCount <= _threshold) revert('MyMultiSig: cannot remove owner below threshold');
+    if (_ownerCount <= _threshold) revert CannotRemoveOwnerBelowThreshold();
     _owners[owner] = false;
     --_ownerCount;
   }
@@ -319,8 +345,8 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   /// @param newThreshold The new threshold.
   /// @dev This function can only be called inside a multisig transaction.
   function _changeThreshold(uint16 newThreshold) private {
-    require(newThreshold > 0, 'MyMultiSig: threshold must be greater than 0');
-    require(newThreshold <= _ownerCount, 'MyMultiSig: threshold must be less than or equal to owner count');
+    if (newThreshold == 0) revert ThresholdMustBeGreaterThanZero();
+    if (newThreshold > _ownerCount) revert ThresholdMustBeLessOrEqualToOwnerCount();
     _threshold = newThreshold;
   }
 
@@ -337,9 +363,9 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   /// @param newOwner The new owner.
   /// @dev This function can only be called inside a multisig transaction.
   function _replaceOwner(address oldOwner, address newOwner) internal virtual {
-    require(_owners[oldOwner], 'MyMultiSig: old owner must be an owner');
-    require(!_owners[newOwner], 'MyMultiSig: new owner must not be an owner');
-    require(newOwner != address(0), 'MyMultiSig: new owner must not be the zero address');
+    if (!_owners[oldOwner]) revert OldOwnerMustBeOwner();
+    if (_owners[newOwner]) revert NewOwnerMustNotBeOwner();
+    if (newOwner == address(0)) revert NewOwnerMustNotBeZero();
     _owners[oldOwner] = false;
     _owners[newOwner] = true;
   }

--- a/contracts/MyMultiSigExtended.sol
+++ b/contracts/MyMultiSigExtended.sol
@@ -16,6 +16,16 @@ contract MyMultiSigExtended is MyMultiSig {
   mapping(address => bool) private _ownersOrDelegates;
   mapping(uint256 => bool) private _noncesUsed;
 
+  error NonceAlreadyUsed();
+  error TransferInactiveOwnershipTooShort();
+  error TransferInactiveOwnershipBelowMinimum();
+  error OwnerMustBeAnOwner();
+  error OwnerIsNotAnOwner();
+  error DelegateeCannotBeZero();
+  error DelegateeAlreadyOwnerOrDelegatee();
+  error SenderNotDelegatee();
+  error OwnerStillActive();
+
   constructor(
     string memory name_,
     address[] memory owners_,
@@ -108,7 +118,7 @@ contract MyMultiSigExtended is MyMultiSig {
     uint256 txnNonce,
     bytes memory signatures
   ) internal virtual override returns (bool valid) {
-    require(!_noncesUsed[txnNonce], 'MyMultiSigExtended: nonce already used');
+    if (_noncesUsed[txnNonce]) revert NonceAlreadyUsed();
     return super._validateSignature(to, value, data, txnGas, txnNonce, signatures);
   }
 
@@ -144,10 +154,7 @@ contract MyMultiSigExtended is MyMultiSig {
   /// @param transferInactiveOwnershipAfter The amount of time after which the other owners can transfer the ownership to a new owner.
   /// @dev This function can only be called inside a multisig transaction.
   function setTransferInactiveOwnershipAfter(uint256 transferInactiveOwnershipAfter) public virtual onlyThis {
-    require(
-      transferInactiveOwnershipAfter >= 7 days,
-      'MyMultiSigExtended: transferInactiveOwnershipAfter must be greater than 7 days'
-    );
+    if (transferInactiveOwnershipAfter < 7 days) revert TransferInactiveOwnershipTooShort();
     _minimumTransferInactiveOwnershipAfter = transferInactiveOwnershipAfter;
   }
 
@@ -161,13 +168,11 @@ contract MyMultiSigExtended is MyMultiSig {
     uint256 transferInactiveOwnershipAfter,
     address delegatee
   ) public virtual onlyThis {
-    require(isOwner(owner), 'MyMultiSigExtended: owner must be an owner');
-    require(
-      transferInactiveOwnershipAfter > _minimumTransferInactiveOwnershipAfter,
-      'MyMultiSigExtended: transferInactiveOwnershipAfter must be greater than _minimumtransferInactiveOwnershipAfter'
-    );
-    require(delegatee != address(0), 'MyMultiSigExtended: delegatee cannot be the zero address');
-    require(!_ownersOrDelegates[delegatee], 'MyMultiSigExtended: delegatee is already an owner or delegatee');
+    if (!isOwner(owner)) revert OwnerMustBeAnOwner();
+    if (transferInactiveOwnershipAfter <= _minimumTransferInactiveOwnershipAfter)
+      revert TransferInactiveOwnershipBelowMinimum();
+    if (delegatee == address(0)) revert DelegateeCannotBeZero();
+    if (_ownersOrDelegates[delegatee]) revert DelegateeAlreadyOwnerOrDelegatee();
     _ownerSettings[owner] = OwnerSettings(block.timestamp, transferInactiveOwnershipAfter, delegatee);
     _ownersOrDelegates[delegatee] = true;
   }
@@ -175,13 +180,11 @@ contract MyMultiSigExtended is MyMultiSig {
   /// @notice Delegatee can take the ownership after the transferInactiveOwnershipAfter time
   /// @param owner The owner address.
   function takeOverOwnership(address owner) external virtual {
-    require(isOwner(owner), 'MyMultiSigExtended: owner is not an owner');
+    if (!isOwner(owner)) revert OwnerIsNotAnOwner();
     OwnerSettings memory tempOwnerSettings = _ownerSettings[owner];
-    require(tempOwnerSettings.delegate == msg.sender, 'MyMultiSigExtended: msg.sender is not the delegatee');
-    require(
-      tempOwnerSettings.lastAction + tempOwnerSettings.transferInactiveOwnershipAfter < block.timestamp,
-      'MyMultiSigExtended: owner is still active'
-    );
+    if (tempOwnerSettings.delegate != msg.sender) revert SenderNotDelegatee();
+    if (tempOwnerSettings.lastAction + tempOwnerSettings.transferInactiveOwnershipAfter >= block.timestamp)
+      revert OwnerStillActive();
     _ownerSettings[owner].delegate = address(0);
     _ownerSettings[msg.sender].lastAction = block.timestamp;
     _ownerSettings[msg.sender].delegate = address(0);

--- a/contracts/test/shared/errors.t.sol
+++ b/contracts/test/shared/errors.t.sol
@@ -3,13 +3,16 @@ pragma solidity ^0.8.0;
 
 import { Test } from 'forge-std/Test.sol';
 
+import { MyMultiSig } from '../../MyMultiSig.sol';
+
 /// @title Errors
-/// @notice Maps a `RevertStatus` enum to the exact revert message emitted by
-///         `MyMultiSig`, then exposes a `verify_revertCall` helper that
-///         stages the expected `vm.expectRevert` on the next call.
+/// @notice Maps a `RevertStatus` enum to the exact custom-error selector emitted
+///         by `MyMultiSig`, then exposes a `verify_revertCall` helper that stages
+///         the expected `vm.expectRevert` on the next call.
 /// @dev    Previously inherited from `DSTest` (re-exported by the now-removed
 ///         `foundry-test-utility`). Switched to `forge-std/Test` so the suite
-///         no longer depends on a private npm package.
+///         no longer depends on a private npm package. Revert reasons moved from
+///         `require`-strings to custom errors, so the map stores 4-byte selectors.
 contract Errors is Test {
   enum RevertStatus {
     Success,
@@ -27,33 +30,33 @@ contract Errors is Test {
     NewOwnerMustNotBeZero
   }
 
-  mapping(RevertStatus => string) private _errors;
+  mapping(RevertStatus => bytes4) private _errors;
 
-  // Associate each revert status with the exact revert message produced by MyMultiSig.
+  // Associate each revert status with the custom-error selector produced by MyMultiSig.
   constructor() {
-    _errors[RevertStatus.OnlyThisContract] = 'MyMultiSig: only this contract can call this function';
-    _errors[RevertStatus.TooManyOwners] = 'MyMultiSig: cannot add owner above 2^16 - 1';
-    _errors[RevertStatus.InvalidSignatures] = 'MyMultiSig: invalid signatures';
-    _errors[RevertStatus.InvalidOwners] = 'MyMultiSig: invalid owner';
-    _errors[RevertStatus.OwnerAlreadySigned] = 'MyMultiSig: owner already signed';
-    _errors[RevertStatus.CannotRemoveOwnerBelowThreshold] = 'MyMultiSig: cannot remove owner below threshold';
-    _errors[RevertStatus.ThresholdMustBeGreaterThanZero] = 'MyMultiSig: threshold must be greater than 0';
+    _errors[RevertStatus.OnlyThisContract] = MyMultiSig.OnlyThisContract.selector;
+    _errors[RevertStatus.TooManyOwners] = MyMultiSig.TooManyOwners.selector;
+    _errors[RevertStatus.InvalidSignatures] = MyMultiSig.InvalidSignatures.selector;
+    _errors[RevertStatus.InvalidOwners] = MyMultiSig.InvalidOwner.selector;
+    _errors[RevertStatus.OwnerAlreadySigned] = MyMultiSig.OwnerAlreadySigned.selector;
+    _errors[RevertStatus.CannotRemoveOwnerBelowThreshold] = MyMultiSig.CannotRemoveOwnerBelowThreshold.selector;
+    _errors[RevertStatus.ThresholdMustBeGreaterThanZero] = MyMultiSig.ThresholdMustBeGreaterThanZero.selector;
     _errors[
       RevertStatus.ThresholdMustBeLessOrEqualThanNumberOfOwners
-    ] = 'MyMultiSig: threshold must be less than or equal to owner count';
-    _errors[RevertStatus.OldOwnerMustBeOwner] = 'MyMultiSig: old owner must be an owner';
-    _errors[RevertStatus.NewOwnerMustNotBeOwner] = 'MyMultiSig: new owner must not be an owner';
-    _errors[RevertStatus.NewOwnerMustNotBeZero] = 'MyMultiSig: new owner must not be the zero address';
+    ] = MyMultiSig.ThresholdMustBeLessOrEqualToOwnerCount.selector;
+    _errors[RevertStatus.OldOwnerMustBeOwner] = MyMultiSig.OldOwnerMustBeOwner.selector;
+    _errors[RevertStatus.NewOwnerMustNotBeOwner] = MyMultiSig.NewOwnerMustNotBeOwner.selector;
+    _errors[RevertStatus.NewOwnerMustNotBeZero] = MyMultiSig.NewOwnerMustNotBeZero.selector;
   }
 
-  function _verify_revertCall(RevertStatus revertType_) internal view returns (string storage) {
+  function _verify_revertCall(RevertStatus revertType_) internal view returns (bytes4) {
     return _errors[revertType_];
   }
 
-  /// @notice Stages a `vm.expectRevert` with the message associated to
+  /// @notice Stages a `vm.expectRevert` with the selector associated to
   ///         `revertType_`. `Success` and `SkipValidation` do not stage a revert.
   function verify_revertCall(RevertStatus revertType_) public {
     if (revertType_ != RevertStatus.Success && revertType_ != RevertStatus.SkipValidation)
-      vm.expectRevert(bytes(_verify_revertCall(revertType_)));
+      vm.expectRevert(_verify_revertCall(revertType_));
   }
 }

--- a/contracts/test/shared/functions.t.sol
+++ b/contracts/test/shared/functions.t.sol
@@ -49,13 +49,14 @@ contract Functions is Constants, Signatures {
     uint256 txnGas,
     uint256 txnNonce
   );
-  event TransactionFailed(
+  event TxFailure(
     address indexed sender,
     address indexed to,
     uint256 indexed value,
     bytes data,
     uint256 txnGas,
-    uint256 txnNonce
+    uint256 txnNonce,
+    bytes reason
   );
   event ContractEndOfLife(uint256 indexed txNonceLefts);
 
@@ -213,7 +214,7 @@ contract Functions is Constants, Signatures {
       emit TransactionExecuted(prank_, to_, value_, data_, txnGas_, nonce_);
     } else {
       vm.expectEmit(true, true, true, false);
-      emit TransactionFailed(prank_, to_, value_, data_, txnGas_, nonce_);
+      emit TxFailure(prank_, to_, value_, data_, txnGas_, nonce_, '');
     }
     multiSig_.execTransaction(to_, value_, data_, txnGas_, signatures_);
 

--- a/test/shared/errors.ts
+++ b/test/shared/errors.ts
@@ -1,30 +1,28 @@
+// Custom-error names as declared on MyMultiSig / MyMultiSigExtended. Asserted
+// with `revertedWithCustomError(contract, name)` (see test/shared/functions.ts).
 export default {
-  ONLY_SELF: 'MyMultiSig: only this contract can call this function',
-  TOO_MANY_OWNERS: 'MyMultiSig: cannot add owner above 2^16 - 1',
-  INVALID_SIGNATURES: 'MyMultiSig: invalid signatures',
-  NOT_ENOUGH_GAS: 'MyMultiSig: not enough gas',
-  NONCE_ALREADY_USED: 'MyMultiSigExtended: nonce already used',
-  OWNER_ALREADY_SIGNED: 'MyMultiSig: owner already signed',
-  CANNOT_REMOVE_OWNERS_BELOW_THRESHOLD: 'MyMultiSig: cannot remove owner below threshold',
+  ONLY_SELF: 'OnlyThisContract',
+  TOO_MANY_OWNERS: 'TooManyOwners',
+  INVALID_SIGNATURES: 'InvalidSignatures',
+  NOT_ENOUGH_GAS: 'NotEnoughGas',
+  NONCE_ALREADY_USED: 'NonceAlreadyUsed',
+  OWNER_ALREADY_SIGNED: 'OwnerAlreadySigned',
+  CANNOT_REMOVE_OWNERS_BELOW_THRESHOLD: 'CannotRemoveOwnerBelowThreshold',
 
-  THRESHOLD_MUST_BE_GREATER_THAN_ZERO: 'MyMultiSig: threshold must be greater than 0',
-  THRESHOLD_MUST_BE_LESS_OR_EQUAL_TO_OWNERS_COUNT: 'MyMultiSig: threshold must be less than or equal to owner count',
+  THRESHOLD_MUST_BE_GREATER_THAN_ZERO: 'ThresholdMustBeGreaterThanZero',
+  THRESHOLD_MUST_BE_LESS_OR_EQUAL_TO_OWNERS_COUNT: 'ThresholdMustBeLessOrEqualToOwnerCount',
 
-  THRESHOLD_NOT_ACHIEVED: 'MyMultiSig: signatures did not reach threshold',
-  INVALID_OWNER: 'MyMultiSig: invalid owner',
+  INVALID_OWNER: 'InvalidOwner',
 
-  OLD_OWNER_NOT_OWNER: 'MyMultiSig: old owner must be an owner',
-  NEW_OWNER_ALREADY_OWNER: 'MyMultiSig: new owner must not be an owner',
-  NEW_OWNER_IS_ZERO_ADDRESS: 'MyMultiSig: new owner must not be the zero address',
+  OLD_OWNER_NOT_OWNER: 'OldOwnerMustBeOwner',
+  NEW_OWNER_ALREADY_OWNER: 'NewOwnerMustNotBeOwner',
+  NEW_OWNER_IS_ZERO_ADDRESS: 'NewOwnerMustNotBeZero',
 
-  INACTIVE_OWNERSHIP_MINIMUM_LESS_THAN_7DAYS:
-    'Can set an amount of time (1 day) after which the other owners can transfer the ownership',
-  OWNER_SETTINGS_MUST_BE_GREATER_THAN_MINIMUM:
-    'MyMultiSigExtended: transferInactiveOwnershipAfter must be greater than _minimumtransferInactiveOwnershipAfter',
-  OWNER_SETTINGS_DELEGATEE_MUST_NOT_BE_OWNER: 'MyMultiSigExtended: delegatee is already an owner or delegatee',
-  OWNER_SETTINGS_OWNER_MUST_BE_OWNER: 'MyMultiSigExtended: owner must be an owner',
-  OWNER_STILL_ACTIVE: 'MyMultiSigExtended: owner is still active',
-  SENDER_NOT_DELEGATEE: 'MyMultiSigExtended: msg.sender is not the delegatee',
+  OWNER_SETTINGS_MUST_BE_GREATER_THAN_MINIMUM: 'TransferInactiveOwnershipBelowMinimum',
+  OWNER_SETTINGS_DELEGATEE_MUST_NOT_BE_OWNER: 'DelegateeAlreadyOwnerOrDelegatee',
+  OWNER_SETTINGS_OWNER_MUST_BE_OWNER: 'OwnerMustBeAnOwner',
+  OWNER_STILL_ACTIVE: 'OwnerStillActive',
+  SENDER_NOT_DELEGATEE: 'SenderNotDelegatee',
 
   PANIC_CODE_0x11:
     'VM Exception while processing transaction: reverted with panic code 0x11 (Arithmetic operation underflowed or overflowed outside of an unchecked block)',

--- a/test/shared/functions.ts
+++ b/test/shared/functions.ts
@@ -24,11 +24,18 @@ export const sendRawTxn = async (input: any, sender: Wallet, ethers: any, provid
   return await provider.waitForTransaction(hash)
 }
 
-export const checkRawTxnResult = async (input: any, sender: Wallet, error: undefined | string) => {
+export const checkRawTxnResult = async (
+  input: any,
+  sender: Wallet,
+  error: undefined | string,
+  contract?: MyMultiSig | MyMultiSigExtended
+) => {
   let result
   if (error)
     if (network.name === 'hardhat' || network.name === 'localhost')
-      await expect(sendRawTxn(input, sender, ethers, ethers.provider)).to.be.revertedWith(error)
+      if (contract)
+        await expect(sendRawTxn(input, sender, ethers, ethers.provider)).to.be.revertedWithCustomError(contract, error)
+      else await expect(sendRawTxn(input, sender, ethers, ethers.provider)).to.be.revertedWith(error)
     else expect.fail('AssertionError: ' + error)
   else {
     result = await sendRawTxn(input, sender, ethers, ethers.provider)
@@ -84,7 +91,7 @@ export const execTransaction = async (
     .connect(submitter)
     .populateTransaction['execTransaction(address,uint256,bytes,uint256,bytes)'](to, value, data, gas, signatures)
 
-  const receipt = await checkRawTxnResult(input, submitter, errorMsg)
+  const receipt = await checkRawTxnResult(input, submitter, errorMsg, contract)
   if (!errorMsg) {
     const event = await getEventFromReceipt(contract, receipt)
     let found = false
@@ -100,9 +107,9 @@ export const execTransaction = async (
       } else {
         if (
           extraEvents &&
-          extraEvents.find((extraEvent: string) => extraEvent === 'TransactionFailed') &&
+          extraEvents.find((extraEvent: string) => extraEvent === 'TxFailure') &&
           event[i] &&
-          event[i].name === 'TransactionFailed'
+          event[i].name === 'TxFailure'
         ) {
           expect(event[i].args.sender).to.be.equal(submitter.address)
           expect(event[i].args.to).to.be.equal(to)
@@ -148,7 +155,7 @@ export const isValidSignature = async (
     const input = await contract
       .connect(submitter)
       .populateTransaction.isValidSignature(to, value, data, gas, nonce, signatures)
-    await checkRawTxnResult(input, submitter, errorMsg)
+    await checkRawTxnResult(input, submitter, errorMsg, contract)
     return false
   }
 }
@@ -341,7 +348,7 @@ export const setTransferInactiveOwnershipAfter = async (
     extraEvents
   )
 
-  if (!errorMsg && (!extraEvents || !extraEvents.find((e) => e === 'TransactionFailed')))
+  if (!errorMsg && (!extraEvents || !extraEvents.find((e) => e === 'TxFailure')))
     expect(await contract.minimumTransferInactiveOwnershipAfter()).to.be.equal(transferInactiveOwnershipAfter)
 }
 
@@ -369,7 +376,7 @@ export const markNonceAsUsed = async (
   )
   expect(await contract.isNonceUsed(nonce)).to.be.true
 
-  if (!errorMsg && (!extraEvents || !extraEvents.find((e) => e === 'TransactionFailed')))
+  if (!errorMsg && (!extraEvents || !extraEvents.find((e) => e === 'TxFailure')))
     expect(await contract.isNonceUsed(nonce)).to.be.false
 }
 
@@ -401,7 +408,7 @@ export const setOwnerSettings = async (
     extraEvents
   )
 
-  if (!errorMsg && (!extraEvents || !extraEvents.includes('TransactionFailed'))) {
+  if (!errorMsg && (!extraEvents || !extraEvents.includes('TxFailure'))) {
     const ownerSettings = await contract.ownerSettings(ownerToConfigure)
     expect(ownerSettings.lastAction).to.be.greaterThan(0)
     expect(ownerSettings.transferInactiveOwnershipAfter).to.be.equal(transferInactiveOwnershipAfter)
@@ -427,7 +434,10 @@ export const takeOverOwnership = async (
     expect(await contract.isOwner(originalOwner)).to.be.false
     // expect(finalOwnerSettings.delegate).to.be.equal(ethers.constants.AddressZero)
   } else {
-    await expect(contract.connect(submitter).takeOverOwnership(originalOwner)).to.be.revertedWith(errorMsg)
+    await expect(contract.connect(submitter).takeOverOwnership(originalOwner)).to.be.revertedWithCustomError(
+      contract,
+      errorMsg
+    )
   }
 }
 
@@ -482,5 +492,5 @@ export const execTransactionWithNonceReverted = async (
     )
   return await expect(
     sendRawTxn(input, submitter, ethers, ethers.provider),
-  ).to.be.revertedWith(errorMsg)
+  ).to.be.revertedWithCustomError(contract, errorMsg)
 }

--- a/test/shared/tests.ts
+++ b/test/shared/tests.ts
@@ -239,7 +239,7 @@ export async function MyMultiSigStandardTests(deploymentType = DeploymentType.Si
         owner03.address,
         undefined,
         Helper.errors.CANNOT_REMOVE_OWNERS_BELOW_THRESHOLD,
-        ['TransactionFailed'],
+        ['TxFailure'],
       )
       await Helper.removeOwner(
         contract,
@@ -248,7 +248,7 @@ export async function MyMultiSigStandardTests(deploymentType = DeploymentType.Si
         owner02.address,
         undefined,
         Helper.errors.CANNOT_REMOVE_OWNERS_BELOW_THRESHOLD,
-        ['TransactionFailed'],
+        ['TxFailure'],
       )
     })
 
@@ -360,7 +360,7 @@ export async function MyMultiSigStandardTests(deploymentType = DeploymentType.Si
       expect(await mockERC20.balanceOf(owner01.address)).to.be.equal(10)
     })
 
-    it('Emit TransactionFailed when valid signature try to execute a invalid call', async function () {
+    it('Emit TxFailure when valid signature try to execute a invalid call', async function () {
       const MockERC20 = await ethers.getContractFactory('MockERC20')
       const data = MockERC20.interface.encodeFunctionData('transferFrom(address,address,uint256)', [
         contract.address,
@@ -376,7 +376,7 @@ export async function MyMultiSigStandardTests(deploymentType = DeploymentType.Si
         data as `0x${string}`,
         Helper.DEFAULT_GAS,
         undefined,
-        ['TransactionFailed'],
+        ['TxFailure'],
       )
     })
 
@@ -840,7 +840,7 @@ export async function MyMultiSigExtendedTests(deploymentType = DeploymentType.Si
         owner03.address,
         undefined,
         Helper.errors.CANNOT_REMOVE_OWNERS_BELOW_THRESHOLD,
-        ['TransactionFailed'],
+        ['TxFailure'],
       )
       await Helper.removeOwner(
         contract,
@@ -849,7 +849,7 @@ export async function MyMultiSigExtendedTests(deploymentType = DeploymentType.Si
         owner02.address,
         undefined,
         Helper.errors.CANNOT_REMOVE_OWNERS_BELOW_THRESHOLD,
-        ['TransactionFailed'],
+        ['TxFailure'],
       )
     })
 
@@ -869,7 +869,7 @@ export async function MyMultiSigExtendedTests(deploymentType = DeploymentType.Si
         ethers.BigNumber.from(60).mul(60).mul(24),
         Helper.DEFAULT_GAS,
         undefined,
-        ['TransactionFailed'],
+        ['TxFailure'],
       )
     })
 
@@ -928,7 +928,7 @@ export async function MyMultiSigExtendedTests(deploymentType = DeploymentType.Si
         ethers.BigNumber.from(60).mul(60).mul(24).mul(5),
         user03.address,
         undefined,
-        ['TransactionFailed'],
+        ['TxFailure'],
       )
     })
 
@@ -941,7 +941,7 @@ export async function MyMultiSigExtendedTests(deploymentType = DeploymentType.Si
         ethers.BigNumber.from(60).mul(60).mul(24).mul(31),
         owner02.address,
         undefined,
-        ['TransactionFailed'],
+        ['TxFailure'],
       )
     })
 
@@ -960,7 +960,7 @@ export async function MyMultiSigExtendedTests(deploymentType = DeploymentType.Si
         ethers.BigNumber.from(60).mul(60).mul(24).mul(5),
         owner03.address,
         undefined,
-        ['TransactionFailed'],
+        ['TxFailure'],
       )
     })
 
@@ -1038,7 +1038,7 @@ export async function MyMultiSigExtendedTests(deploymentType = DeploymentType.Si
           ethers,
           provider,
         ),
-      ).to.be.revertedWith(Helper.errors.ONLY_SELF)
+      ).to.be.revertedWithCustomError(contract, Helper.errors.ONLY_SELF)
     })
 
     it('Cannot setOwnerSettings for a non-owner (isOwner enforced)', async function () {
@@ -1050,7 +1050,7 @@ export async function MyMultiSigExtendedTests(deploymentType = DeploymentType.Si
         ethers.BigNumber.from(60).mul(60).mul(24).mul(8),
         user03.address,
         undefined,
-        ['TransactionFailed'],
+        ['TxFailure'],
       )
     })
 
@@ -1162,7 +1162,7 @@ export async function MyMultiSigExtendedTests(deploymentType = DeploymentType.Si
       expect(await mockERC20.balanceOf(owner01.address)).to.be.equal(10)
     })
 
-    it('Emit TransactionFailed when valid signature try to execute a invalid call', async function () {
+    it('Emit TxFailure when valid signature try to execute a invalid call', async function () {
       const MockERC20 = await ethers.getContractFactory('MockERC20')
       const data = MockERC20.interface.encodeFunctionData('transferFrom(address,address,uint256)', [
         contract.address,
@@ -1178,7 +1178,7 @@ export async function MyMultiSigExtendedTests(deploymentType = DeploymentType.Si
         data as `0x${string}`,
         Helper.DEFAULT_GAS,
         undefined,
-        ['TransactionFailed'],
+        ['TxFailure'],
       )
     })
 


### PR DESCRIPTION
## Summary

`execTransaction` collapsed partial failures silently: signature problems and the gas check reverted with generic `require`-strings, while an on-chain call revert only emitted a reason-less `TransactionFailed` event. Front-ends couldn't tell an **invalid signature** from **insufficient gas** from an **on-chain revert**.

This PR makes each failure mode distinct:

- **Custom errors throughout** `MyMultiSig` and `MyMultiSigExtended` — every `require(string)` / `revert(string)` is now a named custom error (`InvalidSignatures`, `InvalidOwner`, `OwnerAlreadySigned`, `NotEnoughGas`, `OnlyThisContract`, threshold/owner errors, and the Extended set). Cheaper gas, precise client-side decoding.
- **`TxFailure` event with a `reason` field** replaces the reason-less `TransactionFailed`. When the low-level call returns `false`, the raw return data is captured in assembly and emitted as `reason`, so front-ends can decode the target's revert. `execTransaction` still returns the `bool`.
- Signature/gas failures now revert with their own selectors (distinguishable); a soft on-chain revert surfaces via `TxFailure`.

## Test changes

- **Foundry:** `errors.t.sol` maps `RevertStatus` → custom-error selectors; `verify_revertCall` stages `vm.expectRevert(selector)`. Helper event renamed to `TxFailure`.
- **Hardhat:** `errors.ts` holds custom-error names; assertions use `revertedWithCustomError(contract, name)`; failure-event checks renamed to `TxFailure`.

## Test plan

- [x] `forge test` — 75/75 passing
- [x] `yarn hardhat test` — 102 passing; the only 2 failures ("Deployed From Factory") are **pre-existing** (the `MyMultiSigFactory` bytecode exceeds EIP-170), reproduced identically on `main` and unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)