### PR TITLE
fix(factory): reduce factory bytecode size via external deployer helpers

### DIFF
--- a/.github/workflows/hardhat-build-test.yml
+++ b/.github/workflows/hardhat-build-test.yml
@@ -12,6 +12,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+        with:
+          submodules: recursive
       - name: Yarn Install
         run: yarn
       - name: Hardhat Compile

--- a/contracts/MyMultiSigDeployer.sol
+++ b/contracts/MyMultiSigDeployer.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+import './MyMultiSig.sol';
+import './interfaces/IMyMultiSigDeployer.sol';
+
+/// @title MyMultiSigDeployer
+/// @notice Thin wrapper that performs `new MyMultiSig(...)` so the factory
+///         contract doesn't have to embed MyMultiSig's creation bytecode.
+/// @dev    The factory holds this contract's address and forwards the deploy
+///         call here. The MyMultiSig creation bytecode lives in this contract,
+///         not in the factory, which keeps the factory well under the
+///         EIP-170 24,576-byte deployable-code limit.
+contract MyMultiSigDeployer is IMyMultiSigDeployer {
+  function deployMyMultiSig(
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_
+  ) external override returns (address contractAddress) {
+    contractAddress = address(new MyMultiSig(contractName_, owners_, threshold_));
+  }
+}

--- a/contracts/MyMultiSigExtendedDeployer.sol
+++ b/contracts/MyMultiSigExtendedDeployer.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+import './MyMultiSigExtended.sol';
+import './interfaces/IMyMultiSigExtendedDeployer.sol';
+
+/// @title MyMultiSigExtendedDeployer
+/// @notice Thin wrapper that performs `new MyMultiSigExtended(...)` so the
+///         factory contract doesn't have to embed MyMultiSigExtended's
+///         creation bytecode (which is even larger than MyMultiSig's because
+///         of the extra delegation logic).
+/// @dev    Same pattern as `MyMultiSigDeployer` — the factory stores this
+///         contract's address and calls into it.
+contract MyMultiSigExtendedDeployer is IMyMultiSigExtendedDeployer {
+  function deployMyMultiSigExtended(
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_,
+    bool isOnlyOwnerRequest_
+  ) external override returns (address contractAddress) {
+    contractAddress = address(new MyMultiSigExtended(contractName_, owners_, threshold_, isOnlyOwnerRequest_));
+  }
+}

--- a/contracts/MyMultiSigFactory.sol
+++ b/contracts/MyMultiSigFactory.sol
@@ -4,8 +4,13 @@ pragma solidity 0.8.18;
 import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 
 import './abstracts/MyMultiSigFactorable.sol';
-import './MyMultiSigExtended.sol';
 
 contract MyMultiSigFactory is MyMultiSigFactorable, Initializable {
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor(
+    address myMultiSigDeployer_,
+    address myMultiSigExtendedDeployer_
+  ) MyMultiSigFactorable(myMultiSigDeployer_, myMultiSigExtendedDeployer_) {}
+
   function initialize() external initializer {}
 }

--- a/contracts/MyMultiSigFactoryWithChugSplash.sol
+++ b/contracts/MyMultiSigFactoryWithChugSplash.sol
@@ -3,4 +3,9 @@ pragma solidity 0.8.18;
 
 import './abstracts/MyMultiSigFactorable.sol';
 
-contract MyMultiSigFactoryWithChugSplash is MyMultiSigFactorable {}
+contract MyMultiSigFactoryWithChugSplash is MyMultiSigFactorable {
+  constructor(
+    address myMultiSigDeployer_,
+    address myMultiSigExtendedDeployer_
+  ) MyMultiSigFactorable(myMultiSigDeployer_, myMultiSigExtendedDeployer_) {}
+}

--- a/contracts/abstracts/MyMultiSigFactorable.sol
+++ b/contracts/abstracts/MyMultiSigFactorable.sol
@@ -1,14 +1,29 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.18;
 
-import '../MyMultiSigExtended.sol';
+import '../interfaces/IMyMultiSigDeployer.sol';
+import '../interfaces/IMyMultiSigExtendedDeployer.sol';
 import '../libs/MyMultiSigFactorableModels.sol';
 
-contract MyMultiSigFactorable {
+/// @title MyMultiSigFactorable
+/// @notice Shared factory logic: stores bookkeeping for every MyMultiSig /
+///         MyMultiSigExtended instance created through the factory and emits
+///         the `MyMultiSigCreated` event.
+/// @dev    The actual `new MyMultiSig(...)` and `new MyMultiSigExtended(...)`
+///         calls live in two tiny external deployer contracts
+///         (`MyMultiSigDeployer`, `MyMultiSigExtendedDeployer`). Keeping the
+///         deployment bytecode out of this contract drops its size from
+///         ~23 KB to ~3 KB, well below the EIP-170 24,576-byte limit. The
+///         deployer addresses are immutable so they cost nothing at runtime.
+abstract contract MyMultiSigFactorable {
+  /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+  address public immutable myMultiSigDeployer;
+  /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
+  address public immutable myMultiSigExtendedDeployer;
+
   uint256 private _multiSigCount;
 
-  mapping(uint256 => MyMultiSig) private _multiSigs;
-  mapping(address => uint256) private _multiSigIndex;
+  mapping(uint256 => address) private _multiSigs;
   mapping(address => uint256) private _multiSigCreatorCount;
   mapping(address => mapping(uint256 => uint256)) private _multiSigIndexByCreator;
   mapping(uint256 => MyMultiSigFactorableModels.CreationType) private _multiSigCreationType;
@@ -21,6 +36,12 @@ contract MyMultiSigFactorable {
     address[] originalOwners,
     uint16 threshold
   );
+
+  /// @custom:oz-upgrades-unsafe-allow constructor
+  constructor(address myMultiSigDeployer_, address myMultiSigExtendedDeployer_) {
+    myMultiSigDeployer = myMultiSigDeployer_;
+    myMultiSigExtendedDeployer = myMultiSigExtendedDeployer_;
+  }
 
   /// @notice Retrieves the contract name
   /// @return The name as a string memory.
@@ -44,7 +65,7 @@ contract MyMultiSigFactorable {
   /// @param index The index of the multisig
   /// @return The current amount value as a uint256.
   function multiSig(uint256 index) public view returns (address) {
-    return address(_multiSigs[index]);
+    return _multiSigs[index];
   }
 
   /// @notice Retrieves the amount of multisig contract created via this Factory contract by a specific creator
@@ -59,7 +80,7 @@ contract MyMultiSigFactorable {
   /// @param index The index of the multisig
   /// @return The current amount value as a uint256.
   function multiSigByCreator(address creator, uint256 index) public view returns (address) {
-    return address(_multiSigs[_multiSigIndexByCreator[creator][index]]);
+    return _multiSigs[_multiSigIndexByCreator[creator][index]];
   }
 
   /// @notice Retrieves the type of multisig contract created via this Factory contract
@@ -78,15 +99,19 @@ contract MyMultiSigFactorable {
     address[] memory owners,
     uint16 threshold
   ) public payable returns (address contractAddress) {
-    MyMultiSig myMultiSig = new MyMultiSig(contractName, owners, threshold);
-    return
-      _saveCreateMyMultiSig(
-        MyMultiSigFactorableModels.CreationType.SIMPLE,
-        myMultiSig,
-        contractName,
-        owners,
-        threshold
-      );
+    contractAddress = IMyMultiSigDeployer(myMultiSigDeployer).deployMyMultiSig(contractName, owners, threshold);
+
+    _multiSigs[_multiSigCount] = contractAddress;
+    _multiSigIndexByCreator[msg.sender][_multiSigCreatorCount[msg.sender]] = _multiSigCount;
+    unchecked {
+      _multiSigCreatorCount[msg.sender]++;
+    }
+    _multiSigCreationType[_multiSigCount] = MyMultiSigFactorableModels.CreationType.SIMPLE;
+    unchecked {
+      _multiSigCount++;
+    }
+
+    emit MyMultiSigCreated(msg.sender, contractAddress, _multiSigCount, contractName, owners, threshold);
   }
 
   /// @notice Creates a new multisig contract with extended features
@@ -99,39 +124,23 @@ contract MyMultiSigFactorable {
     uint16 threshold,
     bool isOnlyOwnerRequest
   ) public payable returns (address contractAddress) {
-    MyMultiSigExtended myMultiSig = new MyMultiSigExtended(contractName, owners, threshold, isOnlyOwnerRequest);
-    return
-      _saveCreateMyMultiSig(
-        MyMultiSigFactorableModels.CreationType.EXTENDED,
-        MyMultiSig(myMultiSig),
-        contractName,
-        owners,
-        threshold
-      );
-  }
+    contractAddress = IMyMultiSigExtendedDeployer(myMultiSigExtendedDeployer).deployMyMultiSigExtended(
+      contractName,
+      owners,
+      threshold,
+      isOnlyOwnerRequest
+    );
 
-  /// @notice Creates a new multisig contract (internal)
-  /// @param creationType_ The type of creation
-  /// @param myMultiSig_ Contract deployed (casted as MyMultiSig if extended)
-  /// @param contractName_ The name of your multisig contract
-  /// @param owners_ The owners list
-  /// @param threshold_ The amount of owners signature require to execute transactions
-  function _saveCreateMyMultiSig(
-    MyMultiSigFactorableModels.CreationType creationType_,
-    MyMultiSig myMultiSig_,
-    string memory contractName_,
-    address[] memory owners_,
-    uint16 threshold_
-  ) internal returns (address contractAddress) {
-    contractAddress = address(myMultiSig_);
-
-    _multiSigs[_multiSigCount] = myMultiSig_;
-    _multiSigIndex[contractAddress] = _multiSigCount;
+    _multiSigs[_multiSigCount] = contractAddress;
     _multiSigIndexByCreator[msg.sender][_multiSigCreatorCount[msg.sender]] = _multiSigCount;
-    _multiSigCreatorCount[msg.sender]++;
-    _multiSigCreationType[_multiSigCount] = creationType_;
-    _multiSigCount++;
+    unchecked {
+      _multiSigCreatorCount[msg.sender]++;
+    }
+    _multiSigCreationType[_multiSigCount] = MyMultiSigFactorableModels.CreationType.EXTENDED;
+    unchecked {
+      _multiSigCount++;
+    }
 
-    emit MyMultiSigCreated(msg.sender, contractAddress, _multiSigCount, contractName_, owners_, threshold_);
+    emit MyMultiSigCreated(msg.sender, contractAddress, _multiSigCount, contractName, owners, threshold);
   }
 }

--- a/contracts/interfaces/IMyMultiSigDeployer.sol
+++ b/contracts/interfaces/IMyMultiSigDeployer.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+interface IMyMultiSigDeployer {
+  function deployMyMultiSig(
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_
+  ) external returns (address contractAddress);
+}

--- a/contracts/interfaces/IMyMultiSigExtendedDeployer.sol
+++ b/contracts/interfaces/IMyMultiSigExtendedDeployer.sol
@@ -1,0 +1,11 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.18;
+
+interface IMyMultiSigExtendedDeployer {
+  function deployMyMultiSigExtended(
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_,
+    bool isOnlyOwnerRequest_
+  ) external returns (address contractAddress);
+}

--- a/contracts/test/shared/functions.t.sol
+++ b/contracts/test/shared/functions.t.sol
@@ -9,6 +9,8 @@ import { MyMultiSigFactory } from '../../MyMultiSigFactory.sol';
 import { MyMultiSigFactoryWithChugSplash } from '../../MyMultiSigFactoryWithChugSplash.sol';
 import { MyMultiSig } from '../../MyMultiSig.sol';
 import { MyMultiSigExtended } from '../../MyMultiSigExtended.sol';
+import { MyMultiSigDeployer } from '../../MyMultiSigDeployer.sol';
+import { MyMultiSigExtendedDeployer } from '../../MyMultiSigExtendedDeployer.sol';
 
 contract Functions is Constants, Signatures {
   uint8 LOG_LEVEL;
@@ -68,14 +70,20 @@ contract Functions is Constants, Signatures {
     vm.prank(ADMIN);
 
     if (testType_ == TestType.TestWithFactory || testType_ == TestType.TestWithFactory_extended) {
-      myMultiSigFactory = new MyMultiSigFactory();
+      myMultiSigFactory = new MyMultiSigFactory(
+        address(new MyMultiSigDeployer()),
+        address(new MyMultiSigExtendedDeployer())
+      );
       if (testType_ == TestType.TestWithFactory)
         (, myMultiSig) = help_createMultiSig(ADMIN, CONTRACT_NAME, OWNERS, DEFAULT_THRESHOLD);
       // else
       //   (, myMultiSig) = createMyMultiSigExtended(ADMIN, CONTRACT_NAME, OWNERS, DEFAULT_THRESHOLD, ONLY_OWNERS_REQUEST);
     } else if (testType_ == TestType.TestWithChugSplash || testType_ == TestType.TestWithChugSplash_extended) {
       // if (testType_ == TestType.TestWithChugSplash)
-      // myMultiSigFactoryWithChugSplash = new MyMultiSigFactoryWithChugSplash();
+      // myMultiSigFactoryWithChugSplash = new MyMultiSigFactoryWithChugSplash(
+      //   address(new MyMultiSigDeployer()),
+      //   address(new MyMultiSigExtendedDeployer())
+      // );
       // else
       // (, myMultiSig) = help_createMultiSig(ADMIN, CONTRACT_NAME, OWNERS, DEFAULT_THRESHOLD);
     } else if (testType_ == TestType.TestWithoutFactory_extended) {

--- a/hardhat.config.coverage.ts
+++ b/hardhat.config.coverage.ts
@@ -1,4 +1,8 @@
 import { HardhatUserConfig } from 'hardhat/config'
+import { TASK_COMPILE_GET_REMAPPINGS } from 'hardhat/builtin-tasks/task-names'
+import { subtask } from 'hardhat/config'
+import * as fs from 'fs'
+import * as path from 'path'
 import * as dotenv from 'dotenv'
 import '@nomicfoundation/hardhat-toolbox'
 import 'hardhat-awesome-cli'
@@ -6,6 +10,30 @@ import 'hardhat-contract-clarity'
 import '@openzeppelin/hardhat-upgrades'
 
 dotenv.config()
+
+// Mirror the remappings.txt loader from hardhat.config.ts so the coverage
+// build resolves `forge-std/...` and `@openzeppelin/...` imports the same
+// way the regular compile does. Without this, `solidity-coverage` falls
+// back to Hardhat's stock resolver (which returns `{}`) and the build
+// fails with HH404 on `forge-std/Test.sol`.
+subtask(TASK_COMPILE_GET_REMAPPINGS, async (): Promise<Record<string, string>> => {
+  const remappingsFile = path.join(__dirname, 'remappings.txt')
+  if (!fs.existsSync(remappingsFile)) return {}
+
+  const remappings: Record<string, string> = {}
+  for (const rawLine of fs.readFileSync(remappingsFile, 'utf8').split('\n')) {
+    const line = rawLine.trim()
+    if (line.length === 0 || line.startsWith('#')) continue
+    const eq = line.indexOf('=')
+    if (eq === -1) continue
+    const from = line.slice(0, eq).trim()
+    let to = line.slice(eq + 1).trim()
+    if (from.length === 0 || to.length === 0) continue
+    if (!to.endsWith('/')) to = to + '/'
+    remappings[from] = to
+  }
+  return remappings
+})
 
 const {
   RPC_MAINNET,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -84,7 +84,14 @@ const config: HardhatUserConfig = {
   networks: {
     hardhat: {
       // blockGasLimit: 1200000000,
-      gas: 2100000,
+      // Bumped from 2.1M to 6M so the factory's `MyMultiSigDeployer` and
+      // `MyMultiSigExtendedDeployer` helper contracts can be deployed under
+      // the hardhat network. Each helper embeds the full creation bytecode
+      // of `MyMultiSig` / `MyMultiSigExtended`, which pushes a single
+      // deploy transaction over 2.1M gas (~2.27M for the simple helper,
+      // ~2.65M for the extended one). Bumping to 6M leaves headroom for the
+      // OZ upgrades proxy deployment on top.
+      gas: 6000000,
       gasPrice: 8000000000,
     },
     localhost: {

--- a/scripts/deploy.ts
+++ b/scripts/deploy.ts
@@ -1,3 +1,4 @@
+import { ethers, network } from 'hardhat'
 import Helper from '../test/shared'
 
 let provider: any
@@ -26,7 +27,18 @@ async function main() {
   )
   contract = deployment.contract
 
+  // The factory delegates the actual `new MyMultiSig(...)` /
+  // `new MyMultiSigExtended(...)` work to two tiny helper deployer contracts
+  // so it doesn't have to embed their bytecode. Surface their addresses so
+  // the operator can verify the deployment matches the artifacts.
+  const myMultiSigDeployer = await ethers.getContractAt('MyMultiSigDeployer', await contract.myMultiSigDeployer())
+  const myMultiSigExtendedDeployer = await ethers.getContractAt(
+    'MyMultiSigExtendedDeployer',
+    await contract.myMultiSigExtendedDeployer()
+  )
   console.log(`Contract MyMultiSig Factory deployed to ${contract.address}`)
+  console.log(`  -> MyMultiSigDeployer:        ${myMultiSigDeployer.address}`)
+  console.log(`  -> MyMultiSigExtendedDeployer: ${myMultiSigExtendedDeployer.address}`)
 }
 
 main().catch((error) => {

--- a/test/shared/setup.ts
+++ b/test/shared/setup.ts
@@ -39,8 +39,20 @@ const setupContract = async (
   let contract
   // Get contract artifacts and deploy contract
   if (deployFactory) {
+    // The factory doesn't embed MyMultiSig / MyMultiSigExtended bytecode; it
+    // delegates deployment to two tiny helper contracts whose addresses are
+    // passed in via the implementation's constructor. Deploy them first.
+    const MyMultiSigDeployer = await ethers.getContractFactory('MyMultiSigDeployer')
+    const myMultiSigDeployer = await MyMultiSigDeployer.deploy()
+    await myMultiSigDeployer.deployed()
+    const MyMultiSigExtendedDeployer = await ethers.getContractFactory('MyMultiSigExtendedDeployer')
+    const myMultiSigExtendedDeployer = await MyMultiSigExtendedDeployer.deploy()
+    await myMultiSigExtendedDeployer.deployed()
+
     ContractFactory = await ethers.getContractFactory(contractName)
-    contract = await upgrades.deployProxy(ContractFactory, [])
+    contract = await upgrades.deployProxy(ContractFactory, [], {
+      constructorArgs: [myMultiSigDeployer.address, myMultiSigExtendedDeployer.address],
+    })
   } else {
     if (!deployExtended) {
       ContractFactory = await ethers.getContractFactory(contractName)


### PR DESCRIPTION
## Summary

`MyMultiSigFactory` was sitting at **23,536 bytes** and `MyMultiSigFactoryWithChugSplash` at **23,223 bytes** — only ~1 KB below the **EIP-170 24,576-byte deployable-code limit**. With recent feature additions (custom errors, `TxFailure` event, 6-arg `execTransaction`, owner-delegate auth checks), the factory had crept dangerously close to the limit and any further feature work risked pushing it over the on-chain `create` size check.

## Root cause

`contracts/abstracts/MyMultiSigFactorable.sol` called `new MyMultiSig(...)` and `new MyMultiSigExtended(...)` directly. Solidity embeds the creation bytecode of any contract instantiated via `new` in the caller's deployed bytecode, so the factory had to carry the full ~9.4 KB `MyMultiSig` bytecode and ~11.4 KB `MyMultiSigExtended` bytecode (plus their OpenZeppelin ancestors — `ERC721Holder`, `ERC1155Holder`, `EIP712`, `ReentrancyGuard`, `Initializable`).

## Fix

Push the two `new ...(...)` calls into two tiny external helper contracts:

- `contracts/MyMultiSigDeployer.sol` — one function, `new MyMultiSig(...)`. 10,322 bytes.
- `contracts/MyMultiSigExtendedDeployer.sol` — one function, `new MyMultiSigExtended(...)`. 12,412 bytes.

The factory stores their addresses as `immutable`s and forwards the deploy call via a regular external call. The `MyMultiSig` / `MyMultiSigExtended` creation bytecode now lives in the helpers, not in the factory.

## Result

| Contract | Before | After | Δ |
| --- | ---: | ---: | ---: |
| `MyMultiSigFactory` | 23,536 b | **3,046 b** | **-87%** |
| `MyMultiSigFactoryWithChugSplash` | 23,223 b | **2,746 b** | **-88%** |
| `MyMultiSigDeployer` (new) | — | 10,322 b | — |
| `MyMultiSigExtendedDeployer` (new) | — | 12,412 b | — |

All four are well under the 24,576-byte EIP-170 limit.

## Other changes

- Drops the dead `_multiSigIndex` mapping (`MyMultiSigFactorable.sol:11`/`:129`) — written but never read anywhere in the codebase.
- Adds `@custom:oz-upgrades-unsafe-allow constructor` and `@custom:oz-upgrades-unsafe-allow state-variable-immutable` annotations so the OZ upgrades plugin accepts the factory's constructor + immutables (they're intentional — deployer addresses never change across upgrades).
- Bumps the hardhat in-process network's per-tx gas limit from 2.1M to 6M so the deployer helpers (~2.27M / ~2.65M gas to deploy) can be deployed under the OZ upgrades proxy on top.
- Wires the deployer pre-deployment through `test/shared/setup.ts` and `scripts/deploy.ts` so tests and production deploys match.

## Verification

- `yarn hardhat test test/MyMultiSigFromFactory.test.ts` → **80 passing**
- `yarn hardhat test test/MyMultiSig.test.ts` → **80 passing**
- `forge test` → **75 passing**

🤖 Generated with [Claude Code](https://claude.com/claude-code)