### PR TITLE
build(solc): bump from 0.8.18 to 0.8.24, drop legacy 0.8.0 compiler

### DIFF
--- a/contracts/MyMultiSig.sol
+++ b/contracts/MyMultiSig.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import '@openzeppelin/contracts/utils/cryptography/EIP712.sol';

--- a/contracts/MyMultiSigDeployer.sol
+++ b/contracts/MyMultiSigDeployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import './MyMultiSig.sol';
 import './interfaces/IMyMultiSigDeployer.sol';

--- a/contracts/MyMultiSigExtended.sol
+++ b/contracts/MyMultiSigExtended.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import './MyMultiSig.sol';
 

--- a/contracts/MyMultiSigExtendedDeployer.sol
+++ b/contracts/MyMultiSigExtendedDeployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import './MyMultiSigExtended.sol';
 import './interfaces/IMyMultiSigExtendedDeployer.sol';

--- a/contracts/MyMultiSigFactory.sol
+++ b/contracts/MyMultiSigFactory.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import '@openzeppelin/contracts-upgradeable/proxy/utils/Initializable.sol';
 

--- a/contracts/MyMultiSigFactoryWithChugSplash.sol
+++ b/contracts/MyMultiSigFactoryWithChugSplash.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import './abstracts/MyMultiSigFactorable.sol';
 

--- a/contracts/abstracts/MyMultiSigFactorable.sol
+++ b/contracts/abstracts/MyMultiSigFactorable.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import '../interfaces/IMyMultiSigDeployer.sol';
 import '../interfaces/IMyMultiSigExtendedDeployer.sol';

--- a/contracts/interfaces/IMyMultiSigDeployer.sol
+++ b/contracts/interfaces/IMyMultiSigDeployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 interface IMyMultiSigDeployer {
   function deployMyMultiSig(

--- a/contracts/interfaces/IMyMultiSigExtendedDeployer.sol
+++ b/contracts/interfaces/IMyMultiSigExtendedDeployer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 interface IMyMultiSigExtendedDeployer {
   function deployMyMultiSigExtended(

--- a/contracts/libs/MyMultiSigFactorableModels.sol
+++ b/contracts/libs/MyMultiSigFactorableModels.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 library MyMultiSigFactorableModels {
   enum CreationType {

--- a/contracts/test/MyMultiSig.basic.t.sol
+++ b/contracts/test/MyMultiSig.basic.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import { TestBasic } from './shared/tests.t.sol';
 

--- a/contracts/test/MyMultiSig.extended.t.sol
+++ b/contracts/test/MyMultiSig.extended.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import { TestBasic } from './shared/tests.t.sol';
 

--- a/contracts/test/MyMultiSigFactory.basic.t.sol
+++ b/contracts/test/MyMultiSigFactory.basic.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import { TestBasic } from './shared/tests.t.sol';
 

--- a/contracts/test/MyMultiSigFactory.extended.t.sol
+++ b/contracts/test/MyMultiSigFactory.extended.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import { TestBasic } from './shared/tests.t.sol';
 

--- a/contracts/test/MyMultiSigFactoryChugSplash.basic.t.sol
+++ b/contracts/test/MyMultiSigFactoryChugSplash.basic.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import { TestBasic } from './shared/tests.t.sol';
 

--- a/contracts/test/MyMultiSigFactoryChugSplash.extended.t.sol
+++ b/contracts/test/MyMultiSigFactoryChugSplash.extended.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import { TestBasic } from './shared/tests.t.sol';
 

--- a/contracts/test/shared/tests.t.sol
+++ b/contracts/test/shared/tests.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.18;
+pragma solidity 0.8.24;
 
 import { Helper } from './helper.t.sol';
 import { Errors } from './errors.t.sol';

--- a/hardhat.config.coverage.ts
+++ b/hardhat.config.coverage.ts
@@ -203,21 +203,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.18',
-        settings: {
-          optimizer: {
-            enabled: true,
-            runs: 200,
-          },
-          outputSelection: {
-            '*': {
-              '*': ['storageLayout'],
-            },
-          },
-        },
-      },
-      {
-        version: '0.8.0',
+        version: '0.8.24',
         settings: {
           optimizer: {
             enabled: true,

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -217,16 +217,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: '0.8.18',
-        settings: {
-          optimizer: {
-            enabled: true,
-            runs: 200,
-          },
-        },
-      },
-      {
-        version: '0.8.0',
+        version: '0.8.24',
         settings: {
           optimizer: {
             enabled: true,


### PR DESCRIPTION
## Summary

Bump the Solidity compiler from 0.8.18 to 0.8.24 across the project and drop the unused 0.8.0 legacy compiler entry from both Hardhat configs.

- 17 source files: `pragma solidity 0.8.18` → `0.8.24` (production contracts + Foundry tests + shared test helpers)
- `hardhat.config.ts`, `hardhat.config.coverage.ts`: collapse the `[0.8.18, 0.8.0]` compiler array to a single `0.8.24` entry
- `foundry.toml` is untouched — `auto_detect_solc = true` picks up the new pragma automatically
- Mocks using `pragma ^0.8.0` are unchanged; that range already covers 0.8.24

## Why 0.8.24?

It's the latest widely-used 0.8.x line as of mid-2026. Brings:
- Transient storage opcodes (Cancun)
- PUSH0 default (gas savings on deployment)
- Several compiler bugfixes accumulated since 0.8.18

Compatible with `@openzeppelin/contracts@^4.8.3` (the project's OZ pin). OZ 4.9.6 is already in flight via Renovate PR #172; merging that first is fine but not required.

## Why drop 0.8.0?

No source file uses `pragma 0.8.0` or anything narrower than `^0.8.0`. The second compiler entry was unused — it just added compile time without compiling anything. Removing it shrinks the build matrix without changing which sources build against which version.

## Verification

`npx hardhat compile` runs clean against the new pragma and config: downloads solc 0.8.24 and reports **Compiled 98 Solidity files successfully**.

## Caveat

Hardhat 2.12.6 (current `devDependencies` pin) pre-dates full 0.8.24 support. Compile succeeds, but stack traces for 0.8.24-built contracts may be lossy. Hardhat 2.28.6 — which fully supports 0.8.24 — is already proposed via Renovate PR #162. I left that to a separate PR to keep this one focused; recommend merging #162 shortly after this one.

## Test plan

- [ ] `npm run compile` → 98 files, no errors
- [ ] `npm run test` → Hardhat + Foundry suites pass (Foundry picks up the new pragma via auto-detect)
- [ ] (post-merge of #162) Re-verify stack traces look sane in a failed test

🤖 Generated with [Claude Code](https://claude.com/claude-code)