### PR TITLE
refactor(scripts): move transferEth demo script to scripts/dev/fundTestWallets.ts

### DIFF
--- a/scripts/dev/fundTestWallets.ts
+++ b/scripts/dev/fundTestWallets.ts
@@ -1,6 +1,6 @@
 import { ethers } from 'hardhat'
 
-import Helper from '../test/shared'
+import Helper from '../../test/shared'
 
 let provider: any
 let owner01: any


### PR DESCRIPTION
## What

Moves `scripts/transferEth.ts` -> `scripts/dev/fundTestWallets.ts`. Git tracks this as a 97% similarity rename; the only content change is the import path (`../test/shared` -> `../../test/shared`).

## Why

`scripts/transferEth.ts` is a one-off demo: it funds three Metamask test wallets with 1 ETH each from `owner01`'s private key on the hardhat network, purely for an interactive demo. It is not part of the deploy pipeline and should not sit next to production scripts like `deploy.ts`, `upgradeFactory.ts`, `verifyChainlist.ts`, etc.

The user asked us to move it to `scripts/dev/fundTestWallets.ts`, rename clearly, or delete. Move + rename keeps the script discoverable for the demo while clearly separating it from production tooling.

## Verification

- `git grep` confirms no other references to either `transferEth` or `fundTestWallets` exist anywhere in the repo (configs, scripts, tests, docs).
- `tsc --noEmit` reports no errors for the new file path. (The pre-existing type errors in `typechain-types/` and `test/shared/` are unrelated to this change.)

## Out of scope

I deliberately did not refactor the script (e.g. drop the unused `owner02/03/user01-03/deployment/contract` declarations, factor the triple transfer, etc.) to keep this PR focused on the move. Happy to follow up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)