### PR TITLE
fix(multisig): emit OwnerAdded/OwnerRemoved events

### DIFF
--- a/contracts/MyMultiSig.sol
+++ b/contracts/MyMultiSig.sol
@@ -457,6 +457,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     if (_owners[owner]) revert OwnerAlreadyExists();
     _owners[owner] = true;
     ++_ownerCount;
+    emit OwnerAdded(owner);
   }
 
   /// @notice Adds an owner
@@ -475,6 +476,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     if (_ownerCount <= _threshold) revert CannotRemoveOwnerBelowThreshold();
     _owners[owner] = false;
     --_ownerCount;
+    emit OwnerRemoved(owner);
   }
 
   /// @notice Removes an owner
@@ -519,6 +521,8 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     if (newOwner == address(0)) revert NewOwnerMustNotBeZero();
     _owners[oldOwner] = false;
     _owners[newOwner] = true;
+    emit OwnerRemoved(oldOwner);
+    emit OwnerAdded(newOwner);
   }
 
   function generateHash(


### PR DESCRIPTION
## Summary

The contract declared `OwnerAdded` and `OwnerRemoved` events but the internal `_addOwner` / `_removeOwner` / `_replaceOwner` helpers never emitted them, so:

- off-chain consumers / indexers had no log to track owner-set changes
- the existing tests in `test/shared/tests.ts` that pass `['OwnerAdded']` / `['OwnerRemoved']` / `['OwnerRemoved', 'OwnerAdded']` as `extraEvents` were relying on declarations that never fired

## Fix

Emit each event from the matching internal helper, immediately after the storage update so the event reflects the post-mutation owner state:

- `_addOwner(owner)` → `emit OwnerAdded(owner);`
- `_removeOwner(owner)` → `emit OwnerRemoved(owner);`
- `_replaceOwner(oldOwner, newOwner)` → `emit OwnerRemoved(oldOwner); emit OwnerAdded(newOwner);`

`_replaceOwner` emits `OwnerRemoved` before `OwnerAdded` — the order the existing tests assert.

`MyMultiSigExtended` overrides `_addOwner`, `_removeOwner`, and `_replaceOwner` to maintain its `_ownersOrDelegates` bookkeeping, and they call `super.<fn>` — the new emits run there, so the extended contract inherits the same event semantics for free.

Constructor calls `_addOwner` per initial owner, so each one now also emits an `OwnerAdded` log in the deployment receipt — same shape Gnosis Safe-style wallets use.

## Verification

- `yarn hardhat test` → 204 passing
- `forge test` → 81 passing

## Note

`ThresholdChanged` (declared at `MyMultiSig.sol:30`) is also never emitted — same class of bug, but it's out of scope here. Happy to follow up in a separate PR if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)