### PR TITLE
perf: gas optimizations across MyMultiSig wallet family and factory

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# Agent guidelines for mymultisig-contract
+
+Multi-signature wallet smart contracts for [mymultisig.app](https://mymultisig.app). Solidity `0.8.24`, dual toolchain (Hardhat + Foundry).
+
+## Commands
+
+| Task | Command |
+| --- | --- |
+| Compile | `yarn compile` (hardhat) or `forge build` |
+| Test (Hardhat, primary suite) | `npx hardhat test` |
+| Test (Foundry) | `forge test` |
+| Gas snapshot | `forge snapshot` |
+| Regenerate committed ABI + types | `yarn build` |
+| Coverage | `yarn coverage` (hardhat) / `yarn coverage-foundry` |
+| Format contracts | `yarn prettier-contracts` |
+
+Do not run `yarn test` (`test.sh`) from automation — it runs `git pull` and `yarn outdated` interactively.
+
+## Architecture
+
+- `contracts/MyMultiSig.sol` — base wallet: EIP-712 signed transactions, on-chain hash approvals, EIP-1271, batching (`multiRequest` / `multiRequestStrict`).
+- `contracts/MyMultiSigExtended.sol` — extends the base wallet with inactivity/delegate handover, opt-in timelock / guard / allowlist / allowance / modules, an `operation` byte (CALL vs self-DELEGATECALL) and ERC-4337 v0.7 support.
+- `contracts/abstracts/MyMultiSigFactorable.sol` + `contracts/MyMultiSigFactory.sol` — factory bookkeeping; the factory sits behind a TransparentUpgradeableProxy.
+- `contracts/MyMultiSig*Deployer.sol` — thin wrappers holding the wallet creation bytecode so the factory stays under the EIP-170 size limit.
+- Foundry tests live in `contracts/test/`, Hardhat tests in `test/`.
+
+## Storage-layout rules
+
+- **Wallets** (`MyMultiSig`, `MyMultiSigExtended`) are deployed fresh via `new` and are never proxied — their storage layout may change between releases, and new storage is appended at the end of each release block.
+- **The factory** is behind an upgradeable proxy — never reorder, retype, or remove its state variables; only function-body changes and appended variables are safe.
+
+## Code conventions
+
+- **Comments must describe the CURRENT logic only.** Never write comments that describe what was removed, what the code used to do, before/after comparisons ("instead of X", "no longer", "previously"), or the reasoning of changes that are gone. That history belongs in commit messages and PR descriptions, not in the code. A comment must make sense to a reader who has never seen any earlier version of the file.
+- Use custom errors (no `require` strings), NatSpec (`@notice` / `@dev` / `@param` / `@return`) on public surfaces.
+- Commit messages follow Conventional Commits (enforced by commitlint).
+- Generated artifacts: `abi/` is gitignored; `types/` and `constants/` are committed — regenerate with `yarn build` when the ABI changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,10 @@
+# Claude guidance for mymultisig-contract
+
+Full project guide: see @AGENTS.md — architecture, commands, and storage-layout rules live there.
+
+## Rules
+
+- **Comments must describe the CURRENT logic only.** Never write comments that describe what was removed, what the code used to do, before/after comparisons ("instead of X", "no longer", "previously"), or the reasoning of changes that are gone. That history belongs in commit messages and PR descriptions, not in the code. A comment must make sense to a reader who has never seen any earlier version of the file.
+- Run both test suites before committing contract changes: `npx hardhat test` and `forge test`. Do not use `yarn test` (`test.sh`) — it runs `git pull` interactively.
+- The factory (`MyMultiSigFactorable` / `MyMultiSigFactory`) is behind an upgradeable proxy: never reorder, retype, or remove its state variables. Wallets are deployed fresh via `new` and are not proxied.
+- Regenerate committed types with `yarn build` when a contract's ABI changes.

--- a/contracts/MyMultiSig.sol
+++ b/contracts/MyMultiSig.sol
@@ -26,9 +26,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   /// @notice EIP-712 typehash for the per-transaction payload. Includes a
   ///         `uint256 validUntil` deadline so signatures carry an explicit
   ///         expiry. `validUntil == 0` means "no expiry" (matches Safe's
-  ///         convention). Adding the field invalidates every v0.2.0 payload
-  ///         on-chain — see `SignatureExpired` below and the v0.3.0 release
-  ///         notes.
+  ///         convention).
   bytes32 private constant _TRANSACTION_TYPEHASH =
     keccak256('Transaction(address to,uint256 value,bytes data,uint256 gas,uint96 nonce,uint256 validUntil)');
 
@@ -148,13 +146,10 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     return _name;
   }
 
-  /// @notice Wallet version. Unified to `'0.5.0'` across every wallet
-  ///         class on v0.5.0 — same canonical value as
-  ///         `MyMultiSigExtended`, `MyMultiSigFactorable`, and the
-  ///         factory proxy. The EIP-712 domain separator is fixed at
-  ///         deploy time, so pre-existing wallets (deployed before this
-  ///         release) keep their original version while new deployments
-  ///         all bind to the v0.5.0 domain.
+  /// @notice Wallet version — the same canonical value across every wallet
+  ///         class (`MyMultiSigExtended`, `MyMultiSigFactorable`, and the
+  ///         factory proxy). Part of the EIP-712 domain separator, which is
+  ///         fixed at deploy time.
   function version() public pure virtual returns (string memory) {
     return '0.5.0';
   }
@@ -696,9 +691,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   /// @notice Decodes an ABI-encoded `(address owner, bytes sig)[]` blob.
   ///         Centralized so the vote-counting cores (`_checkSignatures` and
   ///         `_validateSignatureForHash`) decode identically. Returns an
-  ///         empty array if the input is empty. The decoded `Vote[]` is
-  ///         consumed directly — no parallel-array copy — so each validation
-  ///         skips two array allocations and a copy loop.
+  ///         empty array if the input is empty.
   function _decodeVotes(bytes memory signatures) internal pure virtual returns (Vote[] memory) {
     if (signatures.length == 0) return new Vote[](0);
     return abi.decode(signatures, (Vote[]));
@@ -850,7 +843,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     _txnNonce++;
   }
 
-  /// @dev Mutation hook so internal `_execTransaction` / v0.5.0's
+  /// @dev Mutation hook so internal `_execTransaction` /
   ///      `_execExtended` can bump the nonce without going through the
   ///      `onlyThis`-guarded `incrementNonce()` public entry (calling
   ///      that from inside `execTransaction` would revert because the

--- a/contracts/MyMultiSig.sol
+++ b/contracts/MyMultiSig.sol
@@ -134,12 +134,13 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     uint256 length = owners_.length;
     if (length > 2 ** 16 - 1) revert TooManyOwners();
     for (uint256 i = 0; i < length; ) {
+      // `_addOwner` already bumps `_ownerCount` once per owner, so the
+      // count is exact after the loop — no final rewrite needed.
       _addOwner(owners_[i]);
       unchecked {
         ++i;
       }
     }
-    _ownerCount = uint16(owners_.length);
     _changeThreshold(threshold_);
   }
 
@@ -319,7 +320,8 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   ///         usable values. Shared by every `execTransaction` overload here
   ///         and in `MyMultiSigExtended`.
   function _emitEndOfLifeIfNear() internal virtual {
-    if (_txnNonce > uint96(2 ** 96 - 1000)) emit ContractEndOfLife(2 ** 96 - _txnNonce - 1);
+    uint96 txnNonce = _txnNonce;
+    if (txnNonce > uint96(2 ** 96 - 1000)) emit ContractEndOfLife(2 ** 96 - txnNonce - 1);
   }
 
   /// @notice Shared low-level CALL wrapper: forwards `txnGas` to `to` with
@@ -490,29 +492,9 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   /// @param signature ABI-encoded `(address owner, bytes sig)[]` of owner votes.
   /// @return magicValue `bytes4(0x1626ba7e)` on success, `bytes4(0xffffffff)` otherwise.
   function isValidSignature(bytes32 hash, bytes memory signature) public view virtual returns (bytes4 magicValue) {
-    uint16 threshold_ = _threshold;
-    address[] storage approved = _approvedOwners[hash];
-    uint256 counted;
-    // On-chain `approveHash` approvals count as votes for this hash without
-    // any signature payload — but only if the approver is still an owner.
-    for (uint256 i; i < approved.length; ) {
-      unchecked {
-        if (!_owners[approved[i]]) return bytes4(0xffffffff);
-        ++counted;
-        ++i;
-      }
-    }
-    if (counted >= threshold_) return _ERC1271_MAGIC;
-    // Decode the signature blob and validate each vote.
-    (address[] memory owners, bytes[] memory sigs) = _decodeVotes(signature);
-    for (uint256 i = 0; i < owners.length; ) {
-      unchecked {
-        if (counted >= threshold_) break;
-        if (_validateVote(hash, owners[i], sigs[i])) ++counted;
-        ++i;
-      }
-    }
-    return counted >= threshold_ ? _ERC1271_MAGIC : bytes4(0xffffffff);
+    // Same vote-counting core as the 6-arg view overload — `_checkSignatures`
+    // ignores its nonce argument, so `0` is a safe placeholder here.
+    return _checkSignatures(hash, 0, signature) ? _ERC1271_MAGIC : bytes4(0xffffffff);
   }
 
   /// @notice Determines if the signature is valid
@@ -557,8 +539,9 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   ) internal view virtual returns (bool valid) {
     uint16 threshold_ = _threshold;
     address[] storage approved = _approvedOwners[txHash];
+    uint256 approvedLength = approved.length;
     uint256 counted;
-    for (uint256 i; i < approved.length; ) {
+    for (uint256 i; i < approvedLength; ) {
       unchecked {
         if (!_owners[approved[i]]) return false;
         ++counted;
@@ -566,11 +549,12 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
       }
     }
     if (counted >= threshold_) return true;
-    (address[] memory owners, bytes[] memory sigs) = _decodeVotes(signatures);
-    for (uint256 i = 0; i < owners.length; ) {
+    Vote[] memory votes = _decodeVotes(signatures);
+    uint256 votesLength = votes.length;
+    for (uint256 i = 0; i < votesLength; ) {
       unchecked {
         if (counted >= threshold_) break;
-        if (_validateVote(txHash, owners[i], sigs[i])) ++counted;
+        if (_validateVote(txHash, votes[i].owner, votes[i].sig)) ++counted;
         ++i;
       }
     }
@@ -690,8 +674,9 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     // slot. An approved owner that was later removed from the wallet fails
     // the check and aborts the whole validation — no partial application.
     address[] storage approved = _approvedOwners[txHash];
+    uint256 approvedLength = approved.length;
     uint256 counted;
-    for (uint256 i; i < approved.length; ) {
+    for (uint256 i; i < approvedLength; ) {
       unchecked {
         address approvedOwner = approved[i];
         if (!_owners[approvedOwner]) return false;
@@ -701,38 +686,28 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
       }
     }
     if (counted >= threshold_) return true;
-    (address[] memory owners, bytes[] memory sigs) = _decodeVotes(signatures);
-    for (uint256 i = 0; i < owners.length; ) {
+    Vote[] memory votes = _decodeVotes(signatures);
+    uint256 votesLength = votes.length;
+    for (uint256 i = 0; i < votesLength; ) {
       unchecked {
         if (counted >= threshold_) break;
-        if (_validateVote(txHash, owners[i], sigs[i]) && _recordVote(txHash, txnNonce, owners[i])) ++counted;
+        if (_validateVote(txHash, votes[i].owner, votes[i].sig) && _recordVote(txHash, txnNonce, votes[i].owner))
+          ++counted;
         ++i;
       }
     }
     return counted >= threshold_;
   }
 
-  /// @notice Decodes an ABI-encoded `(address owner, bytes sig)[]` blob into
-  ///         parallel `address[]` / `bytes[]` arrays. Centralized so the
-  ///         three callers (EIP-1271 entry, 6-arg `isValidSignature`, and
-  ///         `_validateSignature`) decode identically. Returns two empty
-  ///         arrays if the input is empty.
-  function _decodeVotes(bytes memory signatures) internal pure virtual returns (address[] memory, bytes[] memory) {
-    if (signatures.length == 0) return (new address[](0), new bytes[](0));
-    // Decode as an array of tuples. Solidity exposes the elements as fields
-    // on a single `Vote[]` memory value; we then split into parallel arrays.
-    Vote[] memory votes = abi.decode(signatures, (Vote[]));
-    uint256 n = votes.length;
-    address[] memory owners = new address[](n);
-    bytes[] memory sigs = new bytes[](n);
-    for (uint256 i = 0; i < n; ) {
-      unchecked {
-        owners[i] = votes[i].owner;
-        sigs[i] = votes[i].sig;
-        ++i;
-      }
-    }
-    return (owners, sigs);
+  /// @notice Decodes an ABI-encoded `(address owner, bytes sig)[]` blob.
+  ///         Centralized so the vote-counting cores (`_checkSignatures` and
+  ///         `_validateSignatureForHash`) decode identically. Returns an
+  ///         empty array if the input is empty. The decoded `Vote[]` is
+  ///         consumed directly — no parallel-array copy — so each validation
+  ///         skips two array allocations and a copy loop.
+  function _decodeVotes(bytes memory signatures) internal pure virtual returns (Vote[] memory) {
+    if (signatures.length == 0) return new Vote[](0);
+    return abi.decode(signatures, (Vote[]));
   }
 
   /// @notice Storage-free tuple used solely to decode the per-vote signature

--- a/contracts/MyMultiSig.sol
+++ b/contracts/MyMultiSig.sol
@@ -134,8 +134,6 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     uint256 length = owners_.length;
     if (length > 2 ** 16 - 1) revert TooManyOwners();
     for (uint256 i = 0; i < length; ) {
-      // `_addOwner` already bumps `_ownerCount` once per owner, so the
-      // count is exact after the loop — no final rewrite needed.
       _addOwner(owners_[i]);
       unchecked {
         ++i;
@@ -433,8 +431,6 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
         ++i;
       }
     }
-    // `_txnNonce` has already been bumped in `_execTransaction` before this
-    // function is reached, so the outer transaction's nonce is one less.
     emit MultiRequestExecuted(_txnNonce - 1, successes, returnData);
   }
 
@@ -492,8 +488,6 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   /// @param signature ABI-encoded `(address owner, bytes sig)[]` of owner votes.
   /// @return magicValue `bytes4(0x1626ba7e)` on success, `bytes4(0xffffffff)` otherwise.
   function isValidSignature(bytes32 hash, bytes memory signature) public view virtual returns (bytes4 magicValue) {
-    // Same vote-counting core as the 6-arg view overload — `_checkSignatures`
-    // ignores its nonce argument, so `0` is a safe placeholder here.
     return _checkSignatures(hash, 0, signature) ? _ERC1271_MAGIC : bytes4(0xffffffff);
   }
 

--- a/contracts/MyMultiSigAdvancedDeployer.sol
+++ b/contracts/MyMultiSigAdvancedDeployer.sol
@@ -10,12 +10,11 @@ import './interfaces/IMyMultiSigExtendedDeployer.sol';
 ///         without paying for a second copy of the wallet's creation bytecode
 ///         (which already pushes past the EIP-170 24,576-byte limit on the
 ///         extended deployer itself).
-/// @dev    Stores the extended deployer immutably and re-uses it. v0.4.0
-///         Advanced wallets have bytecode-identical twins under the Extended
-///         deployer; the distinction is purely in factory bookkeeping. A
-///         future v0.5.x Advanced-only release can replace this contract
-///         with one that DOES embed a different bytecode, without touching
-///         the factory's call surface.
+/// @dev    Stores the extended deployer immutably and re-uses it. Advanced
+///         wallets are bytecode-identical twins of Extended ones; the
+///         distinction lives purely in factory bookkeeping. An Advanced-only
+///         release can later replace this contract with one that embeds
+///         different bytecode without touching the factory's call surface.
 contract MyMultiSigAdvancedDeployer is IMyMultiSigAdvancedDeployer {
   /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
   address public immutable extendedDeployer;

--- a/contracts/MyMultiSigExtended.sol
+++ b/contracts/MyMultiSigExtended.sol
@@ -7,13 +7,12 @@ import './interfaces/IAccount.sol';
 import './interfaces/IEntryPoint.sol';
 import './interfaces/PackedUserOperation.sol';
 
-/// @title MyMultiSigExtended (v0.5.0)
-/// @notice v0.3.0 inactivity / delegate handover, v0.4.0 opt-in
-///         features (timelock, guard, allowlist, allowance, modules),
-///         and v0.5.0 additions: an `operation` byte on
+/// @title MyMultiSigExtended
+/// @notice Extends `MyMultiSig` with inactivity / delegate handover,
+///         opt-in features (timelock, guard, allowlist, allowance,
+///         modules — all disabled by default), an `operation` byte on
 ///         `execTransaction` (0 = CALL, 1 = DELEGATECALL gated to
-///         `to == address(this)`) and ERC-4337 v0.7 account abstraction.
-///         All four v0.4.0 features remain disabled by default.
+///         `to == address(this)`), and ERC-4337 v0.7 account abstraction.
 /// @dev    Storage is appended at the END of each release so later
 ///         versions never collide with earlier storage slots.
 contract MyMultiSigExtended is MyMultiSig, IAccount {
@@ -34,10 +33,9 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
 
   // Hot-path feature gates. `_guard`, `_allowedTargetsEnabled` and
   // `_timelockDelay` are all read by `_preExecChecks` on EVERY
-  // `execTransaction`, so they are packed into a single storage slot
-  // (160 + 8 + 88 bits): one cold SLOAD per exec instead of three
-  // (~4200 gas saved on the default disabled-features path). The uint88
-  // delay caps at ~9.8e18 years — effectively unbounded;
+  // `execTransaction`, so they share a single storage slot
+  // (160 + 8 + 88 bits) and the gates pay one cold SLOAD per exec. The
+  // uint88 delay caps at ~9.8e18 years — effectively unbounded;
   // `setTimelockDelay` enforces the cap.
   address internal _guard;
   bool internal _allowedTargetsEnabled; // first `setAllowedTarget` flips this on
@@ -47,9 +45,9 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   uint256 internal _sensitiveValueThreshold; // 0 = value-cap disabled
   /// @dev Tri-state override of the built-in default sensitive-selector set
   ///      (see `_isDefaultSensitiveSelector`): 0 = use the default set,
-  ///      1 = forced sensitive, 2 = forced not sensitive. Keeping the
-  ///      defaults in code instead of 10 constructor SSTOREs makes every
-  ///      wallet deployment ~220k gas cheaper with identical semantics.
+  ///      1 = forced sensitive, 2 = forced not sensitive. The default set
+  ///      lives in code, not storage, so wallet deployment pays no
+  ///      per-selector SSTOREs.
   mapping(bytes4 => uint8) internal _sensitiveSelectorOverride;
   mapping(bytes32 => uint256) internal _readyAt; // 0 = unscheduled, max = executed
   mapping(bytes32 => uint256) internal _scheduledValidUntil;
@@ -147,10 +145,8 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   // Constructor
   // ---------------------------------------------------------------------------
   /// @custom:oz-upgrades-unsafe-allow constructor
-  /// @dev    v0.5.0 adds an `entryPoint_` constructor arg. Existing
-  ///         v0.4.0 on-chain instances of `MyMultiSigExtended` are
-  ///         frozen at their original bytecode — they continue to use
-  ///         `version() == '0.4.0'` and do NOT have the v0.5.0 surface.
+  /// @dev    `entryPoint_` pins the ERC-4337 EntryPoint for the wallet's
+  ///         lifetime and must be non-zero.
   constructor(
     string memory name_,
     address[] memory owners_,
@@ -183,17 +179,16 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
   IEntryPoint public immutable ENTRY_POINT;
 
-  /// @notice Wallet version. Unified to `'0.5.0'` across every wallet
-  ///         class on this release. The EIP-712 domain separator is
-  ///         therefore shared with `MyMultiSig` and the factory; only
-  ///         the typehash differs here (a 7-field hash binds the
-  ///         `operation` byte; the base wallet uses a 6-field hash).
+  /// @notice Wallet version — same canonical value as the base wallet and
+  ///         the factory, so the EIP-712 domain separator is shared; only
+  ///         the typehash differs (a 7-field hash binds the `operation`
+  ///         byte; the base wallet uses a 6-field hash).
   function version() public pure virtual override returns (string memory) {
     return '0.5.0';
   }
 
   // ---------------------------------------------------------------------------
-  // v0.3.0 view / read functions (unchanged)
+  // v0.3.0 view / read functions
   // ---------------------------------------------------------------------------
 
   /// @notice Retrieves if the contract only accepts owner requests (use for UI and other integrations)
@@ -220,14 +215,11 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
     return _noncesUsed[nonce];
   }
 
-  /// @notice v0.5.0 — DISABLED overload of the v0.4.0 7-arg
-  ///         `execTransaction(to, value, data, gas, txnNonce,
-  ///         validUntil, signatures)` (with `txnNonce + validUntil` but
-  ///         no `operation` byte). v0.5.0 binds the operation byte into
-  ///         the EIP-712 payload; callers must use one of the new
-  ///         6/7/8-arg overloads at the bottom of this contract that
-  ///         include `operation`. Reverts with
-  ///         `RequiresOperationByte()`.
+  /// @notice Disabled overload: this wallet binds the `operation` byte
+  ///         into the EIP-712 payload, so `execTransaction` calls without
+  ///         an `operation` argument always revert with
+  ///         `RequiresOperationByte()`. Use one of the `operation`-carrying
+  ///         overloads declared at the bottom of this contract.
   function execTransaction(
     address /* to */,
     uint256 /* value */,
@@ -237,15 +229,11 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
     uint256 /* validUntil */,
     bytes memory /* signatures */
   ) public payable virtual nonReentrant returns (bool /* success */) {
-    // v0.5.0 requires the `operation` byte on the EIP-712 payload. The
-    // v0.4.0 7-arg overload (with `txnNonce + validUntil` but no
-    // `operation`) is unreachable; callers must use one of the new
-    // overloads at the bottom of this contract.
     revert RequiresOperationByte();
   }
 
   // ---------------------------------------------------------------------------
-  // v0.3.0 overrides (unchanged)
+  // v0.3.0 overrides
   // ---------------------------------------------------------------------------
 
   /// @notice Bumps `lastAction` for the owner whenever their vote is recorded
@@ -302,7 +290,7 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   }
 
   // ---------------------------------------------------------------------------
-  // v0.3.0 mutators (unchanged)
+  // v0.3.0 mutators
   // ---------------------------------------------------------------------------
 
   function setOnlyOwnerRequest(bool isOnlyOwnerRequest) public virtual onlyThis {
@@ -432,13 +420,13 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
     bytes memory signatures
   ) public payable virtual nonReentrant returns (bytes32 txHash) {
     if (_timelockDelay == 0) revert ZeroDelayForSensitive();
-    // v0.5.0 — extended wallets sign over the 7-field typehash so the
+    // Extended wallets sign over the 7-field typehash, so the
     // timelock-ready hash must match it. operation is locked to 0 here:
     // timelock only applies to admin calls (CALL, not DELEGATECALL).
     txHash = generateHashOp(to, value, data, txnGas, txnNonce, validUntil, 0);
     if (_readyAt[txHash] != 0) revert AlreadyScheduled(txHash);
     if (validUntil != 0 && block.timestamp > validUntil) revert SignatureExpired();
-    // Use the v0.5.0 mutating validator (records per-`(nonce, owner)`
+    // Use the mutating validator (records per-`(nonce, owner)`
     // slot via `_recordVote`) so schedules consume the same vote slot
     // a direct `execTransaction` would, blocking replays.
     if (!_validateSignatureOp(txHash, txnNonce, validUntil, signatures)) revert InvalidSignatures();
@@ -579,8 +567,8 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   ) public payable virtual nonReentrant returns (bool success) {
     if (signatures.length != 65) revert AllowanceRequiresSingleSigner();
     uint96 currentNonce = nonce();
-    // v0.5.0 — Extended wallets bind `operation` into the EIP-712 typehash;
-    // the allowance path uses the new 7-field typehash with operation = 0.
+    // Extended wallets bind `operation` into the EIP-712 typehash; the
+    // allowance path uses the 7-field typehash with operation = 0.
     bytes32 txHash = generateHashOp(to, value, data, txnGas, currentNonce, validUntil, 0);
     address recovered = _recoverSigner(signatures, txHash);
     if (recovered != msg.sender || !isOwner(recovered)) revert AllowanceRequiresSingleSigner();
@@ -740,7 +728,7 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   // v0.4.0 — _execTransaction orchestrator + per-feature pre/post hooks
   // ---------------------------------------------------------------------------
 
-  /// @notice v0.4.0 override: pre-checks → base path → post-check (silent).
+  /// @notice Orchestrator override: pre-checks → base path → post-check (silent).
   function _execTransaction(
     address to,
     uint256 value,
@@ -808,7 +796,7 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   // v0.4.0 — per-inner-call gate for multiRequest / multiRequestStrict
   // ---------------------------------------------------------------------------
 
-  /// @notice Runs the v0.4.0 gates (timelock reverse-route, guard,
+  /// @notice Runs the pre-exec gates (timelock reverse-route, guard,
   ///         allowlist) before every inner call of the base `multiRequest` /
   ///         `multiRequestStrict` loops. The base calls this hook per item,
   ///         so the batch loops themselves live only in `MyMultiSig.sol`.
@@ -855,9 +843,9 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
     return false;
   }
 
-  /// @dev ECDSA recovery for the allowance path. Mirrors `MyMultiSig.sol:595-599`
-  ///      but operates on `bytes memory` directly. Returns `address(0)` on
-  ///      malformed input; the caller verifies against `msg.sender` and owners.
+  /// @dev ECDSA recovery for the allowance path. Mirrors the ECDSA branch
+  ///      of `_validateVote`. Returns `address(0)` on malformed input; the
+  ///      caller verifies against `msg.sender` and owners.
   function _recoverSigner(bytes memory sig, bytes32 txHash) internal pure virtual returns (address) {
     bytes32 r;
     bytes32 s;
@@ -884,7 +872,7 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   // v0.5.0 — `operation` byte on execTransaction + ERC-4337 v0.7
   // ---------------------------------------------------------------------------
 
-  /// @notice v0.5.0 EIP-712 typehash (binds `operation`).
+  /// @notice EIP-712 typehash for the 7-field payload (binds `operation`).
   bytes32 private constant _TRANSACTION_TYPEHASH_OP =
     keccak256(
       'Transaction(address to,uint256 value,bytes data,uint256 gas,uint96 nonce,uint256 validUntil,uint8 operation)'
@@ -894,10 +882,11 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   uint256 private constant _SIG_VALIDATION_SUCCESS = 0;
   uint256 private constant _SIG_VALIDATION_FAILED = 1;
 
-  /// @notice v0.5.0 events. The base `TransactionExecuted` / `TxFailure`
-  ///         / `ContractEndOfLife` events still fire so existing indexers
-  ///         keep working; these carry `operation` so off-chain consumers
-  ///         can distinguish CALL vs DELEGATECALL.
+  /// @notice Operation-carrying twins of the base `TransactionExecuted` /
+  ///         `TxFailure` events. The base events fire alongside these so
+  ///         indexers that only know the base surface keep working; the
+  ///         `operation` field lets off-chain consumers distinguish CALL
+  ///         from DELEGATECALL.
   event TransactionExecutedOp(
     address indexed sender,
     address indexed to,
@@ -960,9 +949,9 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
     _emitEndOfLifeIfNear();
   }
 
-  // Disabled overrides — the v0.4.0 overloads (no `operation` byte) are
-  // unreachable on v0.5.0. The actual `override` lives at the original
-  // 7-arg declaration further up in this file.
+  // Disabled overrides — the base wallet's overloads without an
+  // `operation` byte always revert on this wallet; callers must use the
+  // `operation`-carrying overloads above.
 
   function execTransaction(
     address /* to */,
@@ -1074,9 +1063,9 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
     if (operation > 1) revert InvalidOperation(operation);
     if (operation == 1 && to != address(this)) revert InvalidOperation(operation);
 
-    // Run the same v0.4.0 pre-exec gates (timelock reverse-route, guard,
-    // allowlist) the base `_execTransaction` override does. Without this,
-    // v0.5.0 calls bypassing the v0.4.0 overloads would skip these gates.
+    // Run the same pre-exec gates (timelock reverse-route, guard,
+    // allowlist) as the `_execTransaction` override, so every exec entry
+    // point hits them.
     _preExecChecks(to, value, data);
 
     bytes32 txHash = generateHashOp(to, value, data, txnGas, txnNonce, validUntil, operation);

--- a/contracts/MyMultiSigExtended.sol
+++ b/contracts/MyMultiSigExtended.sol
@@ -32,8 +32,18 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
 
   // --- v0.4.0 storage ---
 
+  // Hot-path feature gates. `_guard`, `_allowedTargetsEnabled` and
+  // `_timelockDelay` are all read by `_preExecChecks` on EVERY
+  // `execTransaction`, so they are packed into a single storage slot
+  // (160 + 8 + 88 bits): one cold SLOAD per exec instead of three
+  // (~4200 gas saved on the default disabled-features path). The uint88
+  // delay caps at ~9.8e18 years — effectively unbounded;
+  // `setTimelockDelay` enforces the cap.
+  address internal _guard;
+  bool internal _allowedTargetsEnabled; // first `setAllowedTarget` flips this on
+  uint88 internal _timelockDelay; // 0 = disabled
+
   // Timelock
-  uint256 internal _timelockDelay; // 0 = disabled
   uint256 internal _sensitiveValueThreshold; // 0 = value-cap disabled
   /// @dev Tri-state override of the built-in default sensitive-selector set
   ///      (see `_isDefaultSensitiveSelector`): 0 = use the default set,
@@ -45,9 +55,7 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   mapping(bytes32 => uint256) internal _scheduledValidUntil;
 
   // Guard / allowlist
-  address internal _guard;
   mapping(address => bool) internal _allowedTargets;
-  bool internal _allowedTargetsEnabled; // first `setAllowedTarget` flips this on
 
   // Allowance
   mapping(address => uint256) internal _dailyLimitPerOwner;
@@ -75,6 +83,10 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   error TimelockNotReady(bytes32 txHash, uint256 readyAt, uint256 blockTimestamp);
   error SensitiveCallRequiresDelay(address to, bytes4 selector, uint256 value);
   error ZeroDelayForSensitive();
+  /// @notice `setTimelockDelay` rejects delays above `type(uint88).max`
+  ///         (~9.8e18 years) — the delay shares a packed slot with the
+  ///         guard address and allowlist flag. Any real-world delay fits.
+  error DelayTooLong();
   error AlreadyScheduled(bytes32 txHash);
   error NotScheduled(bytes32 txHash);
   error NotSensitive();
@@ -388,7 +400,8 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   ///         a sensitive selector (registered in the constructor), so
   ///         reducing the delay also goes through the slow path.
   function setTimelockDelay(uint256 delay) public virtual onlyThis {
-    _timelockDelay = delay;
+    if (delay > type(uint88).max) revert DelayTooLong();
+    _timelockDelay = uint88(delay);
     emit TimelockDelaySet(delay);
   }
 

--- a/contracts/MyMultiSigExtendedDeployer.sol
+++ b/contracts/MyMultiSigExtendedDeployer.sol
@@ -9,11 +9,8 @@ import './interfaces/IMyMultiSigExtendedDeployer.sol';
 ///         the factory doesn't have to embed the wallet's creation
 ///         bytecode (which is even larger than MyMultiSig's because of
 ///         the extra delegation / 4337 / operation-byte logic).
-/// @dev    v0.5.0 adds an `entryPoint_` argument; the deployer forwards
-///         it through to the wallet's constructor. The factory
-///         `createMyMultiSigExtended(...)` is unchanged at the
-///         `MyMultiSigFactorable` level — the new `entryPoint_` arg is
-///         stored on the factory as a v0.5.0 surface addition.
+/// @dev    Forwards every argument — including `entryPoint_` — straight
+///         through to the wallet's constructor.
 contract MyMultiSigExtendedDeployer is IMyMultiSigExtendedDeployer {
   function deployMyMultiSigExtended(
     string memory contractName_,

--- a/contracts/MyMultiSigFactory.sol
+++ b/contracts/MyMultiSigFactory.sol
@@ -7,20 +7,14 @@ import './abstracts/MyMultiSigFactorable.sol';
 
 /// @title MyMultiSigFactory
 /// @notice The upgradeable factory proxy implementation. Bundles:
-///         - the v0.4.0 / v0.5.0 factory bookkeeping
-///           (`MyMultiSigFactorable`),
+///         - the factory bookkeeping (`MyMultiSigFactorable`),
 ///         - an `Initializable` proxy setup so the contract can sit
 ///           behind a TransparentUpgradeableProxy and be upgraded in
 ///           place.
 ///
-/// @dev    v0.5.0 simplified the factory back to the v0.4.0 constructor
-///         shape — there is no separate `MyMultiSigExtended` deployer /
-///         implementation slot. `MyMultiSigExtended` is now the
-///         v0.5.0 wallet; the same `MyMultiSigExtendedDeployer` deploys
-///         it (now taking an `entryPoint_` argument). The factory
-///         already stores that deployer as an immutable; nothing
-///         changes on the factory's storage side beyond the wallet
-///         class itself gaining the new constructor arg.
+/// @dev    All three wallet deployers are stored as immutables on
+///         `MyMultiSigFactorable`; the factory itself holds no wallet
+///         creation bytecode.
 contract MyMultiSigFactory is MyMultiSigFactorable, Initializable {
   /// @custom:oz-upgrades-unsafe-allow constructor
   constructor(
@@ -35,9 +29,8 @@ contract MyMultiSigFactory is MyMultiSigFactorable, Initializable {
     )
   {}
 
-  /// @notice Bootstrap initializer for chains that have not yet shipped
-  ///         the v0.4.0 factory. Implemented as `external initializer`
-  ///         so the proxy upgrade passes OZ's hardhat-upgrades layout
-  ///         check on first deploy.
+  /// @notice Bootstrap initializer for first-time proxy deployments.
+  ///         Implemented as `external initializer` so the deployment
+  ///         passes OZ's hardhat-upgrades layout check.
   function initialize() external initializer {}
 }

--- a/contracts/abstracts/MyMultiSigFactorable.sol
+++ b/contracts/abstracts/MyMultiSigFactorable.sol
@@ -141,6 +141,32 @@ abstract contract MyMultiSigFactorable {
     return _multiSigCreationType[index] == MyMultiSigFactorableModels.CreationType.ADVANCED;
   }
 
+  /// @dev Shared post-deploy bookkeeping for the three `create*` entry
+  ///      points. Reads `_multiSigCount` / `_multiSigCreatorCount` once into
+  ///      locals instead of re-loading them for every mapping write, and
+  ///      keeps the bookkeeping bytecode in one place.
+  /// @return newCount The post-increment global count — the same value the
+  ///         `MyMultiSigCreated` event has always carried as `contractIndex`.
+  function _recordMultiSig(
+    address contractAddress,
+    MyMultiSigFactorableModels.CreationType kind
+  ) private returns (uint256 newCount) {
+    uint256 count = _multiSigCount;
+    uint256 creatorCount = _multiSigCreatorCount[msg.sender];
+    _multiSigs[count] = contractAddress;
+    _multiSigIndexByCreator[msg.sender][creatorCount] = count;
+    _multiSigCreationType[count] = kind;
+    _creationTypeByAddress[contractAddress] = kind;
+    unchecked {
+      _multiSigCreatorCount[msg.sender] = creatorCount + 1;
+      if (kind == MyMultiSigFactorableModels.CreationType.SIMPLE) _simpleCount++;
+      else if (kind == MyMultiSigFactorableModels.CreationType.EXTENDED) _extendedCount++;
+      else _advancedCount++;
+      newCount = count + 1;
+    }
+    _multiSigCount = newCount;
+  }
+
   /// @notice Creates a new base `MyMultiSig` wallet.
   /// @param contractName The wallet's name (shown in the EIP-712 domain).
   /// @param owners The owners list.
@@ -152,19 +178,9 @@ abstract contract MyMultiSigFactorable {
   ) public payable returns (address contractAddress) {
     contractAddress = IMyMultiSigDeployer(myMultiSigDeployer).deployMyMultiSig(contractName, owners, threshold);
 
-    _multiSigs[_multiSigCount] = contractAddress;
-    _multiSigIndexByCreator[msg.sender][_multiSigCreatorCount[msg.sender]] = _multiSigCount;
-    unchecked {
-      _multiSigCreatorCount[msg.sender]++;
-    }
-    _multiSigCreationType[_multiSigCount] = MyMultiSigFactorableModels.CreationType.SIMPLE;
-    _creationTypeByAddress[contractAddress] = MyMultiSigFactorableModels.CreationType.SIMPLE;
-    unchecked {
-      _simpleCount++;
-      _multiSigCount++;
-    }
+    uint256 newCount = _recordMultiSig(contractAddress, MyMultiSigFactorableModels.CreationType.SIMPLE);
 
-    emit MyMultiSigCreated(msg.sender, contractAddress, _multiSigCount, contractName, owners, threshold);
+    emit MyMultiSigCreated(msg.sender, contractAddress, newCount, contractName, owners, threshold);
   }
 
   /// @notice Creates a new `MyMultiSigExtended` wallet via the Extended
@@ -191,19 +207,9 @@ abstract contract MyMultiSigFactorable {
       entryPoint
     );
 
-    _multiSigs[_multiSigCount] = contractAddress;
-    _multiSigIndexByCreator[msg.sender][_multiSigCreatorCount[msg.sender]] = _multiSigCount;
-    unchecked {
-      _multiSigCreatorCount[msg.sender]++;
-    }
-    _multiSigCreationType[_multiSigCount] = MyMultiSigFactorableModels.CreationType.EXTENDED;
-    _creationTypeByAddress[contractAddress] = MyMultiSigFactorableModels.CreationType.EXTENDED;
-    unchecked {
-      _extendedCount++;
-      _multiSigCount++;
-    }
+    uint256 newCount = _recordMultiSig(contractAddress, MyMultiSigFactorableModels.CreationType.EXTENDED);
 
-    emit MyMultiSigCreated(msg.sender, contractAddress, _multiSigCount, contractName, owners, threshold);
+    emit MyMultiSigCreated(msg.sender, contractAddress, newCount, contractName, owners, threshold);
   }
 
   /// @notice Creates a new `MyMultiSigExtended`-class wallet via the Advanced
@@ -227,18 +233,8 @@ abstract contract MyMultiSigFactorable {
       entryPoint
     );
 
-    _multiSigs[_multiSigCount] = contractAddress;
-    _multiSigIndexByCreator[msg.sender][_multiSigCreatorCount[msg.sender]] = _multiSigCount;
-    unchecked {
-      _multiSigCreatorCount[msg.sender]++;
-    }
-    _multiSigCreationType[_multiSigCount] = MyMultiSigFactorableModels.CreationType.ADVANCED;
-    _creationTypeByAddress[contractAddress] = MyMultiSigFactorableModels.CreationType.ADVANCED;
-    unchecked {
-      _advancedCount++;
-      _multiSigCount++;
-    }
+    uint256 newCount = _recordMultiSig(contractAddress, MyMultiSigFactorableModels.CreationType.ADVANCED);
 
-    emit MyMultiSigCreated(msg.sender, contractAddress, _multiSigCount, contractName, owners, threshold);
+    emit MyMultiSigCreated(msg.sender, contractAddress, newCount, contractName, owners, threshold);
   }
 }

--- a/contracts/abstracts/MyMultiSigFactorable.sol
+++ b/contracts/abstracts/MyMultiSigFactorable.sol
@@ -143,10 +143,9 @@ abstract contract MyMultiSigFactorable {
 
   /// @dev Shared post-deploy bookkeeping for the three `create*` entry
   ///      points. Reads `_multiSigCount` / `_multiSigCreatorCount` once into
-  ///      locals instead of re-loading them for every mapping write, and
-  ///      keeps the bookkeeping bytecode in one place.
-  /// @return newCount The post-increment global count — the same value the
-  ///         `MyMultiSigCreated` event has always carried as `contractIndex`.
+  ///      locals and touches each storage slot exactly once.
+  /// @return newCount The post-increment global count, emitted by the
+  ///         callers as the `contractIndex` of `MyMultiSigCreated`.
   function _recordMultiSig(
     address contractAddress,
     MyMultiSigFactorableModels.CreationType kind
@@ -184,9 +183,8 @@ abstract contract MyMultiSigFactorable {
   }
 
   /// @notice Creates a new `MyMultiSigExtended` wallet via the Extended
-  ///         deployer. v0.5.0 takes an EntryPoint address — the
-  ///         factory's caller is responsible for passing the canonical
-  ///         v0.7 EntryPoint (or zero to disable 4337; see notes).
+  ///         deployer. The caller is responsible for passing the
+  ///         canonical v0.7 EntryPoint address.
   /// @param entryPoint Canonical EntryPoint v0.7 address. Required to
   ///        be non-zero so the wallet constructor's `InvalidOperation`
   ///        check passes; pass the constant
@@ -214,7 +212,7 @@ abstract contract MyMultiSigFactorable {
 
   /// @notice Creates a new `MyMultiSigExtended`-class wallet via the Advanced
   ///         deployer. Currently routes to the Extended deployer (the
-  ///         v0.4.0 / v0.5.0 wallet bytecode is identical); the factory
+  ///         wallet bytecode is identical); the factory
   ///         uses a separate code path so future Advanced-only features
   ///         can ship without re-deploying the wallet. Same
   ///         `entryPoint` semantics as `createMyMultiSigExtended`.


### PR DESCRIPTION
## Summary

Gas-focused pass over the `MyMultiSig*` contracts. No public-interface or behavioral changes except one new guard: `setTimelockDelay` now rejects delays above `type(uint88).max` (~9.8e18 years) with a new `DelayTooLong` error.

### MyMultiSig.sol
- `_decodeVotes` returns the decoded `Vote[]` directly instead of splitting it into parallel `address[]`/`bytes[]` arrays — kills two array allocations plus a copy loop on every signature validation.
- Storage-array lengths are cached in the vote-counting loops (one SLOAD instead of one per iteration).
- The EIP-1271 `isValidSignature(bytes32,bytes)` entry point delegates to the shared `_checkSignatures` core instead of duplicating it (bytecode/deploy-gas reduction).
- Removed a redundant `_ownerCount` rewrite in the constructor and a duplicate `_txnNonce` SLOAD in `_emitEndOfLifeIfNear`.

### MyMultiSigExtended.sol
- `_guard`, `_allowedTargetsEnabled` and `_timelockDelay` (now `uint88`) are packed into a single storage slot. All three are read by `_preExecChecks` on **every** `execTransaction`, so the default disabled-features path pays one cold SLOAD instead of three (~4200 gas saved per exec). Wallets are deployed fresh via `new` (never proxied), so the slot reordering only affects new deployments.

### MyMultiSigFactorable.sol
- The three `create*` functions share a new `_recordMultiSig` helper that reads `_multiSigCount` / `_multiSigCreatorCount[msg.sender]` once into locals (~5 warm SLOADs saved per creation). Function-body-only change — storage layout and the `MyMultiSigCreated` event payload are unchanged, keeping the upgradeable factory proxy layout-compatible.

## Measured impact (forge snapshot diff)

| Path | Before | After | Saved |
|---|---|---|---|
| Extended wallet `execTransaction` (e.g. addOwner) | 255,777 | 249,567 | **~6,210** |
| Base wallet `execTransaction` (e.g. addOwner) | 173,076 | 170,812 | **~2,264** |
| Extended `multiRequestStrict` | 296,324 | 290,218 | ~6,106 |

66 of 118 forge tests got cheaper; the only regression is +1,820 on a 16.7M-gas 100-owner mega-test (+0.01%, optimizer code-layout noise).

## Testing
- `forge test`: 118/118 pass
- `npx hardhat test`: 273/273 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)