### PR TITLE
feat: session keys (temporary signers) + signMessage off-chain auth

### DIFF
--- a/contracts/MyMultiSig.sol
+++ b/contracts/MyMultiSig.sol
@@ -22,6 +22,12 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   ///         in the order they called `approveHash`. Stored as an array so
   ///         `getApprovedOwners` can return it without an extra off-chain indexer.
   mapping(bytes32 => address[]) private _approvedOwners;
+  /// @notice Messages the wallet has signed on-chain via `signMessage`.
+  ///         Keyed by the EIP-712 message hash (see `getMessageHash`), so a
+  ///         stored entry is bound to this wallet's domain separator and
+  ///         cannot be replayed against another wallet. Read by the
+  ///         EIP-1271 `isValidSignature(bytes32,bytes)` empty-signature path.
+  mapping(bytes32 => bool) private _signedMessages;
 
   /// @notice EIP-712 typehash for the per-transaction payload. Includes a
   ///         `uint256 validUntil` deadline so signatures carry an explicit
@@ -29,6 +35,13 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   ///         convention).
   bytes32 private constant _TRANSACTION_TYPEHASH =
     keccak256('Transaction(address to,uint256 value,bytes data,uint256 gas,uint96 nonce,uint256 validUntil)');
+
+  /// @notice EIP-712 typehash for off-chain-auth messages signed via
+  ///         `signMessage`. Mirrors Safe's `SafeMessage(bytes message)`
+  ///         pattern: the raw message bytes are hashed into the wallet's
+  ///         EIP-712 domain, so the resulting hash is unique per wallet,
+  ///         chain, and message.
+  bytes32 private constant _MSG_TYPEHASH = keccak256('MyMultiSigMessage(bytes message)');
 
   /// @notice EIP-1271 magic value: `isValidSignature(bytes32,bytes)` must return
   ///         this 4-byte value when the signature is valid. Equal to
@@ -92,6 +105,13 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   ///         path return value when the call succeeded. `txNonce` is the
   ///         outer `execTransaction` nonce under which the batch ran.
   event MultiRequestExecuted(uint256 indexed txNonce, bool[] successes, bytes[] returnData);
+  /// @notice Emitted when the wallet signs a message on-chain via
+  ///         `signMessage`. `msgHash` is the EIP-712 message hash returned
+  ///         by `getMessageHash(message)`.
+  event MessageSigned(bytes32 indexed msgHash);
+  /// @notice Emitted when a previously-signed message is withdrawn via
+  ///         `unsignMessage`, so EIP-1271 verifiers stop accepting it.
+  event MessageUnsigned(bytes32 indexed msgHash);
 
   error OnlyThisContract();
   error TooManyOwners();
@@ -105,6 +125,9 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   ///         by `revokeApproval(bytes32)` when the caller is an owner but
   ///         has no entry in `_approvedHashes[hash]`.
   error NotApproved();
+  /// @notice `unsignMessage` was called for a message the wallet never
+  ///         signed (or already unsigned).
+  error MessageNotSigned();
   /// @notice Emitted by `multiRequestStrict` when an inner call reverts.
   ///         `index` is the 0-based position of the failing call in the
   ///         batch; `reason` is the raw return data of that call so
@@ -480,10 +503,59 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   ///         — the in-wallet `_validateSignature` path does that, but the
   ///         EIP-1271 entry point is generic over the hash.
   /// @param hash The hash the caller wants validated.
-  /// @param signature ABI-encoded `(address owner, bytes sig)[]` of owner votes.
+  /// @param signature ABI-encoded `(address owner, bytes sig)[]` of owner
+  ///        votes, or empty bytes to check for an on-chain `signMessage`
+  ///        approval of `hash` (see `signMessage`).
   /// @return magicValue `bytes4(0x1626ba7e)` on success, `bytes4(0xffffffff)` otherwise.
   function isValidSignature(bytes32 hash, bytes memory signature) public view virtual returns (bytes4 magicValue) {
+    if (signature.length == 0 && _signedMessages[getMessageHash(abi.encode(hash))]) return _ERC1271_MAGIC;
     return _checkSignatures(hash, 0, signature) ? _ERC1271_MAGIC : bytes4(0xffffffff);
+  }
+
+  /// @notice Builds the EIP-712 hash of an off-chain-auth message. The hash
+  ///         binds the raw `message` bytes into this wallet's domain
+  ///         separator (name, version, chainId, wallet address), so the
+  ///         same message produces a different hash on every wallet.
+  /// @param message The raw message bytes. To authorize a 32-byte digest
+  ///        `dataHash` for EIP-1271 verifiers, pass `abi.encode(dataHash)`.
+  /// @return The EIP-712 message hash used as the `_signedMessages` key.
+  function getMessageHash(bytes memory message) public view virtual returns (bytes32) {
+    return _hashTypedDataV4(keccak256(abi.encode(_MSG_TYPEHASH, keccak256(message))));
+  }
+
+  /// @notice Marks `message` as signed by the wallet, with full threshold
+  ///         consensus: the call must run inside an `execTransaction`
+  ///         (`onlyThis`), so it carries the same signature requirements as
+  ///         any other wallet action. Once signed, EIP-1271 verifiers that
+  ///         call `isValidSignature(dataHash, '')` — with an EMPTY signature
+  ///         — get the magic value back for `message == abi.encode(dataHash)`.
+  ///         This lets the wallet prove control off-chain (SIWE, order
+  ///         pre-signing, ownership attestations) without any owner
+  ///         signature present at verification time.
+  /// @param message The raw message bytes (see `getMessageHash`).
+  function signMessage(bytes memory message) public virtual onlyThis {
+    bytes32 msgHash = getMessageHash(message);
+    _signedMessages[msgHash] = true;
+    emit MessageSigned(msgHash);
+  }
+
+  /// @notice Withdraws a previous `signMessage(message)` so EIP-1271
+  ///         verifiers stop accepting the empty-signature proof. Requires
+  ///         threshold consensus (`onlyThis`), same as `signMessage`.
+  /// @param message The raw message bytes that were previously signed.
+  function unsignMessage(bytes memory message) public virtual onlyThis {
+    bytes32 msgHash = getMessageHash(message);
+    if (!_signedMessages[msgHash]) revert MessageNotSigned();
+    _signedMessages[msgHash] = false;
+    emit MessageUnsigned(msgHash);
+  }
+
+  /// @notice Whether the wallet has signed the message with this EIP-712
+  ///         message hash (see `getMessageHash`) via `signMessage`.
+  /// @param msgHash The EIP-712 message hash.
+  /// @return True if the message is currently signed.
+  function isMessageSigned(bytes32 msgHash) public view virtual returns (bool) {
+    return _signedMessages[msgHash];
   }
 
   /// @notice Determines if the signature is valid

--- a/contracts/interfaces/IModuleWallet.sol
+++ b/contracts/interfaces/IModuleWallet.sol
@@ -1,0 +1,23 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+/// @title IModuleWallet
+/// @notice The minimal `MyMultiSigExtended` surface a module contract needs:
+///         the module-driven execution entry point and the owner check used
+///         for module-level access control (e.g. single-owner emergency
+///         revocation in `SessionKeyModule`).
+interface IModuleWallet {
+  /// @notice Module-driven execution. The wallet reverts with `NotAModule`
+  ///         unless `msg.sender` is a currently-enabled module. Guard and
+  ///         allowlist gates still apply inside the wallet.
+  /// @param operation 0 = CALL, 1 = DELEGATECALL (gated to `to == wallet`).
+  function execTransactionFromModule(
+    address to,
+    uint256 value,
+    bytes memory data,
+    uint256 operation
+  ) external payable returns (bool success);
+
+  /// @notice Whether `owner` is a current owner of the wallet.
+  function isOwner(address owner) external view returns (bool);
+}

--- a/contracts/modules/SessionKeyModule.sol
+++ b/contracts/modules/SessionKeyModule.sol
@@ -1,0 +1,249 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
+
+import '../interfaces/IModuleWallet.sol';
+
+/// @title SessionKeyModule
+/// @notice Time-bounded, scope-limited session keys ("temporary signers")
+///         for `MyMultiSigExtended` wallets — e.g. "this key can call
+///         Uniswap for 24 hours, spending up to 1 ETH" — without touching
+///         the wallet's permanent owner set or threshold.
+///
+///         One deployed instance serves any number of wallets. A wallet
+///         opts in by enabling this module (`enableModule`, threshold-
+///         gated) and then granting keys via `grantSessionKey` — also
+///         threshold-gated, because the wallet itself must be the caller.
+///         The key holder executes with a plain transaction from the key:
+///         `executeWithSessionKey(wallet, to, value, data)`.
+///
+///         Every grant is bounded on three axes:
+///         - time: `[validAfter, validUntil]` unix window;
+///         - scope: an explicit target allowlist (mandatory) plus an
+///           optional function-selector allowlist;
+///         - value: a cumulative wei budget across the whole session.
+///
+///         A session key can NEVER call the wallet itself, so it cannot
+///         reach `addOwner` / `changeThreshold` / `enableModule` or any
+///         other `onlyThis` admin surface. The wallet's guard and
+///         allowlist gates still run inside `execTransactionFromModule`.
+///
+///         Revocation is deliberately cheaper than granting: the wallet
+///         (threshold) OR any single current owner can revoke a key
+///         immediately — a leaked session key must not stay live while a
+///         quorum is assembled.
+contract SessionKeyModule is ReentrancyGuard {
+  struct SessionKey {
+    /// @notice Unix timestamp the key becomes usable at. `0` = immediately.
+    uint48 validAfter;
+    /// @notice Unix timestamp the key expires at (inclusive). `0` = no grant.
+    uint48 validUntil;
+    /// @notice Bumped on every grant and revoke. Target / selector scope
+    ///         entries are keyed by epoch, so a re-grant or revoke
+    ///         invalidates the previous scope without iterating it.
+    uint64 epoch;
+    /// @notice When true, only calldata whose selector is in the grant's
+    ///         selector set is allowed. Plain ETH transfers (calldata
+    ///         shorter than 4 bytes) match the sentinel selector
+    ///         `bytes4(0)`, which must be allowed explicitly.
+    bool restrictSelectors;
+    /// @notice Total wei the key may spend over the session.
+    uint256 ethBudget;
+    /// @notice Wei spent so far. Only successful calls are charged.
+    uint256 ethSpent;
+  }
+
+  /// @notice wallet => session key address => grant.
+  mapping(address => mapping(address => SessionKey)) private _sessionKeys;
+  /// @notice Allowed call targets, keyed by `keccak256(abi.encode(wallet,
+  ///         key, epoch, target))` so stale epochs never match.
+  mapping(bytes32 => bool) private _allowedTarget;
+  /// @notice Allowed function selectors, keyed by `keccak256(abi.encode(
+  ///         wallet, key, epoch, selector))` so stale epochs never match.
+  mapping(bytes32 => bool) private _allowedSelector;
+
+  event SessionKeyGranted(
+    address indexed wallet,
+    address indexed key,
+    uint48 validAfter,
+    uint48 validUntil,
+    uint256 ethBudget,
+    address[] targets,
+    bytes4[] selectors
+  );
+  event SessionKeyRevoked(address indexed wallet, address indexed key, address revoker);
+  event SessionKeyUsed(
+    address indexed wallet,
+    address indexed key,
+    address indexed to,
+    uint256 value,
+    bytes data,
+    bool success
+  );
+
+  error SessionKeyZeroAddress();
+  error SessionKeyInvalidWindow(uint48 validAfter, uint48 validUntil);
+  error SessionKeyNoTargets();
+  error SessionKeyTargetIsWallet();
+  error SessionKeyNotActive(address wallet, address key);
+  error SessionKeyTargetNotAllowed(address to);
+  error SessionKeySelectorNotAllowed(bytes4 selector);
+  error SessionKeyBudgetExceeded(uint256 requested, uint256 remaining);
+  error SessionKeyCannotCallWallet();
+  error NotWalletOrOwner(address caller);
+
+  // ---------------------------------------------------------------------------
+  // Grant / revoke — `msg.sender` is the wallet (grant) or wallet/owner (revoke)
+  // ---------------------------------------------------------------------------
+
+  /// @notice Grants (or re-grants, overwriting scope and resetting the
+  ///         spent counter) a session key for the calling wallet. Must be
+  ///         invoked BY the wallet, i.e. through a threshold-signed
+  ///         `execTransaction` that targets this module.
+  /// @param key The temporary signer address. Must be non-zero.
+  /// @param validAfter Unix timestamp the key activates at; `0` = now.
+  /// @param validUntil Unix timestamp the key expires at (inclusive). Must
+  ///        be in the future and after `validAfter`.
+  /// @param ethBudget Total wei the key may spend over the session.
+  /// @param targets Allowed call targets. Mandatory (at least one), and the
+  ///        wallet itself is never allowed.
+  /// @param selectors Optional allowed function selectors. Empty = any
+  ///        selector on the allowed targets. Include `bytes4(0)` to allow
+  ///        plain ETH transfers when restricting selectors.
+  function grantSessionKey(
+    address key,
+    uint48 validAfter,
+    uint48 validUntil,
+    uint256 ethBudget,
+    address[] calldata targets,
+    bytes4[] calldata selectors
+  ) external {
+    if (key == address(0)) revert SessionKeyZeroAddress();
+    if (validUntil <= block.timestamp || validAfter >= validUntil)
+      revert SessionKeyInvalidWindow(validAfter, validUntil);
+    if (targets.length == 0) revert SessionKeyNoTargets();
+
+    SessionKey storage sk = _sessionKeys[msg.sender][key];
+    uint64 epoch = sk.epoch + 1;
+    sk.validAfter = validAfter;
+    sk.validUntil = validUntil;
+    sk.epoch = epoch;
+    sk.restrictSelectors = selectors.length > 0;
+    sk.ethBudget = ethBudget;
+    sk.ethSpent = 0;
+
+    for (uint256 i = 0; i < targets.length; ) {
+      address target = targets[i];
+      if (target == address(0)) revert SessionKeyZeroAddress();
+      if (target == msg.sender) revert SessionKeyTargetIsWallet();
+      _allowedTarget[keccak256(abi.encode(msg.sender, key, epoch, target))] = true;
+      unchecked {
+        ++i;
+      }
+    }
+    for (uint256 i = 0; i < selectors.length; ) {
+      _allowedSelector[keccak256(abi.encode(msg.sender, key, epoch, selectors[i]))] = true;
+      unchecked {
+        ++i;
+      }
+    }
+    emit SessionKeyGranted(msg.sender, key, validAfter, validUntil, ethBudget, targets, selectors);
+  }
+
+  /// @notice Revokes a session key immediately. Callable by the wallet
+  ///         itself (threshold path) or by ANY single current owner of the
+  ///         wallet, so a leaked key can be killed without waiting for a
+  ///         quorum.
+  /// @param wallet The wallet the key was granted for.
+  /// @param key The session key to revoke.
+  function revokeSessionKey(address wallet, address key) external {
+    if (msg.sender != wallet && !IModuleWallet(wallet).isOwner(msg.sender)) revert NotWalletOrOwner(msg.sender);
+    SessionKey storage sk = _sessionKeys[wallet][key];
+    if (sk.validUntil == 0) revert SessionKeyNotActive(wallet, key);
+    // Bumping the epoch orphans every target / selector entry of the
+    // revoked grant; zeroing `validUntil` returns the key to "no grant".
+    sk.epoch += 1;
+    sk.validAfter = 0;
+    sk.validUntil = 0;
+    sk.restrictSelectors = false;
+    sk.ethBudget = 0;
+    sk.ethSpent = 0;
+    emit SessionKeyRevoked(wallet, key, msg.sender);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Execution — `msg.sender` is the session key
+  // ---------------------------------------------------------------------------
+
+  /// @notice Executes `(to, value, data)` through `wallet` as the calling
+  ///         session key. The key must be inside its time window, `to`
+  ///         must be in the grant's target set (and never the wallet
+  ///         itself), the selector must pass the optional selector set,
+  ///         and `value` must fit the remaining budget. The budget is
+  ///         charged before the call and refunded if the inner call
+  ///         fails, so a reentrant attempt can never overspend.
+  /// @return success Whether the inner call succeeded. Reverts with a
+  ///         payload are bubbled up by the wallet instead.
+  function executeWithSessionKey(
+    address wallet,
+    address to,
+    uint256 value,
+    bytes calldata data
+  ) external nonReentrant returns (bool success) {
+    SessionKey storage sk = _sessionKeys[wallet][msg.sender];
+    if (sk.validUntil == 0 || block.timestamp > sk.validUntil || block.timestamp < sk.validAfter)
+      revert SessionKeyNotActive(wallet, msg.sender);
+    if (to == wallet) revert SessionKeyCannotCallWallet();
+    uint64 epoch = sk.epoch;
+    if (!_allowedTarget[keccak256(abi.encode(wallet, msg.sender, epoch, to))]) revert SessionKeyTargetNotAllowed(to);
+    if (sk.restrictSelectors) {
+      bytes4 selector = data.length >= 4 ? bytes4(data[:4]) : bytes4(0);
+      if (!_allowedSelector[keccak256(abi.encode(wallet, msg.sender, epoch, selector))])
+        revert SessionKeySelectorNotAllowed(selector);
+    }
+    uint256 spent = sk.ethSpent + value;
+    if (spent > sk.ethBudget) revert SessionKeyBudgetExceeded(value, sk.ethBudget - sk.ethSpent);
+    sk.ethSpent = spent;
+
+    success = IModuleWallet(wallet).execTransactionFromModule(to, value, data, 0);
+    if (!success) sk.ethSpent = spent - value;
+    emit SessionKeyUsed(wallet, msg.sender, to, value, data, success);
+  }
+
+  // ---------------------------------------------------------------------------
+  // Views
+  // ---------------------------------------------------------------------------
+
+  /// @notice Full grant record for `(wallet, key)`. `validUntil == 0`
+  ///         means no active grant.
+  function sessionKey(address wallet, address key) public view returns (SessionKey memory) {
+    return _sessionKeys[wallet][key];
+  }
+
+  /// @notice Whether the key is usable right now (granted and inside its
+  ///         time window). Does not consider the remaining budget.
+  function isSessionKeyActive(address wallet, address key) public view returns (bool) {
+    SessionKey storage sk = _sessionKeys[wallet][key];
+    return sk.validUntil != 0 && block.timestamp <= sk.validUntil && block.timestamp >= sk.validAfter;
+  }
+
+  /// @notice Whether the key's current grant allows calling `target`.
+  function isSessionTargetAllowed(address wallet, address key, address target) public view returns (bool) {
+    return _allowedTarget[keccak256(abi.encode(wallet, key, _sessionKeys[wallet][key].epoch, target))];
+  }
+
+  /// @notice Whether the key's current grant allows `selector`. Always true
+  ///         when the grant doesn't restrict selectors.
+  function isSessionSelectorAllowed(address wallet, address key, bytes4 selector) public view returns (bool) {
+    SessionKey storage sk = _sessionKeys[wallet][key];
+    if (!sk.restrictSelectors) return true;
+    return _allowedSelector[keccak256(abi.encode(wallet, key, sk.epoch, selector))];
+  }
+
+  /// @notice Remaining wei the key may still spend in its session.
+  function sessionBudgetRemaining(address wallet, address key) public view returns (uint256) {
+    SessionKey storage sk = _sessionKeys[wallet][key];
+    return sk.ethBudget > sk.ethSpent ? sk.ethBudget - sk.ethSpent : 0;
+  }
+}

--- a/contracts/test/MyMultiSig.signMessage.t.sol
+++ b/contracts/test/MyMultiSig.signMessage.t.sol
@@ -1,0 +1,116 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import { Helper } from './shared/helper.t.sol';
+import { MyMultiSig } from '../MyMultiSig.sol';
+
+/// @title signMessage / EIP-1271 off-chain-auth Foundry tests
+/// @notice Covers the on-chain message-signing surface of the base wallet:
+///         1. `getMessageHash` binds the message into the wallet's
+///            EIP-712 domain (`MyMultiSigMessage(bytes message)`).
+///         2. `signMessage` requires threshold consensus (`onlyThis`) and
+///            flips the EIP-1271 empty-signature path to the magic value.
+///         3. `unsignMessage` withdraws the approval.
+///         4. The threshold-signature EIP-1271 path keeps working.
+contract MyMultiSigSignMessageTest is Helper {
+  bytes4 internal constant MAGIC = 0x1626ba7e;
+  bytes4 internal constant NOT_MAGIC = 0xffffffff;
+
+  function setUp() public {
+    initialize_helper(LOG_LEVEL, TestType.TestWithoutFactory);
+  }
+
+  function _ownersPk() internal view returns (uint256[] memory pks) {
+    pks = new uint256[](2);
+    pks[0] = OWNERS_PK[0];
+    pks[1] = OWNERS_PK[1];
+  }
+
+  /// @dev Runs `signMessage(message)` (or `unsignMessage`) through a
+  ///      threshold-signed `execTransaction`.
+  function _execSignMessage(bytes memory message, bool sign) internal {
+    bytes memory data = sign
+      ? abi.encodeWithSignature('signMessage(bytes)', message)
+      : abi.encodeWithSignature('unsignMessage(bytes)', message);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      address(myMultiSig),
+      0,
+      data,
+      DEFAULT_GAS,
+      build_signatures(myMultiSig, _ownersPk(), address(myMultiSig), 0, data, DEFAULT_GAS)
+    );
+  }
+
+  function test_getMessageHash_matches_manual_eip712() public {
+    bytes memory message = bytes('prove wallet control');
+    bytes32 domainSeparator = build_domainSeparator(myMultiSig, CONTRACT_NAME);
+    bytes32 structHash = keccak256(
+      abi.encode(keccak256('MyMultiSigMessage(bytes message)'), keccak256(message))
+    );
+    bytes32 expected = keccak256(abi.encodePacked('\x19\x01', domainSeparator, structHash));
+    assertEq(myMultiSig.getMessageHash(message), expected);
+  }
+
+  function test_signMessage_direct_call_reverts_onlyThis() public {
+    vm.prank(OWNERS[0]);
+    vm.expectRevert(abi.encodeWithSignature('OnlyThisContract()'));
+    myMultiSig.signMessage(bytes('nope'));
+  }
+
+  function test_signMessage_enables_empty_signature_eip1271() public {
+    bytes32 dataHash = keccak256('siwe:login:mymultisig.app');
+    bytes memory message = abi.encode(dataHash);
+
+    // Unsigned wallet: the empty-signature path must NOT validate.
+    assertEq(myMultiSig.isValidSignature(dataHash, bytes('')), NOT_MAGIC);
+    assertFalse(myMultiSig.isMessageSigned(myMultiSig.getMessageHash(message)));
+
+    _execSignMessage(message, true);
+
+    assertTrue(myMultiSig.isMessageSigned(myMultiSig.getMessageHash(message)));
+    assertEq(myMultiSig.isValidSignature(dataHash, bytes('')), MAGIC);
+  }
+
+  function test_signMessage_is_wallet_specific() public {
+    bytes32 dataHash = keccak256('shared payload');
+    _execSignMessage(abi.encode(dataHash), true);
+    assertEq(myMultiSig.isValidSignature(dataHash, bytes('')), MAGIC);
+
+    // A sibling wallet with the same owners never signed the message, so
+    // its empty-signature path must reject the same dataHash.
+    MyMultiSig sibling = new MyMultiSig(CONTRACT_NAME, OWNERS, DEFAULT_THRESHOLD);
+    assertEq(sibling.isValidSignature(dataHash, bytes('')), NOT_MAGIC);
+  }
+
+  function test_unsignMessage_withdraws_approval() public {
+    bytes32 dataHash = keccak256('temporary authorization');
+    bytes memory message = abi.encode(dataHash);
+    _execSignMessage(message, true);
+    assertEq(myMultiSig.isValidSignature(dataHash, bytes('')), MAGIC);
+
+    _execSignMessage(message, false);
+    assertFalse(myMultiSig.isMessageSigned(myMultiSig.getMessageHash(message)));
+    assertEq(myMultiSig.isValidSignature(dataHash, bytes('')), NOT_MAGIC);
+  }
+
+  function test_unsignMessage_reverts_when_never_signed() public {
+    vm.prank(address(myMultiSig));
+    vm.expectRevert(abi.encodeWithSignature('MessageNotSigned()'));
+    myMultiSig.unsignMessage(bytes('never signed'));
+  }
+
+  function test_threshold_signature_path_still_validates() public {
+    // The pre-existing EIP-1271 behavior — threshold owner votes over an
+    // arbitrary hash — must keep working alongside the stored-message path.
+    bytes32 hash = keccak256('external protocol digest');
+    Vote[] memory votes = new Vote[](2);
+    for (uint256 i = 0; i < 2; i++) {
+      (uint8 v, bytes32 r, bytes32 s) = vm.sign(OWNERS_PK[i], hash);
+      votes[i] = Vote({ owner: OWNERS[i], sig: abi.encodePacked(r, s, v) });
+    }
+    assertEq(myMultiSig.isValidSignature(hash, abi.encode(votes)), MAGIC);
+    assertEq(myMultiSig.isValidSignature(keccak256('other digest'), abi.encode(votes)), NOT_MAGIC);
+  }
+}

--- a/contracts/test/SessionKeyModule.t.sol
+++ b/contracts/test/SessionKeyModule.t.sol
@@ -1,0 +1,290 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import { Helper } from './shared/helper.t.sol';
+import { MyMultiSigExtended } from '../MyMultiSigExtended.sol';
+import { SessionKeyModule } from '../modules/SessionKeyModule.sol';
+
+/// @dev Simple scoped target for session-key tests: accepts ETH and
+///      exposes two selectors so the selector-allowlist paths can be
+///      exercised.
+contract MockSessionTarget {
+  uint256 public pings;
+  uint256 public pongs;
+
+  function ping() external payable {
+    pings++;
+  }
+
+  function pong() external payable {
+    pongs++;
+  }
+
+  receive() external payable {}
+}
+
+/// @title SessionKeyModule Foundry tests
+/// @notice Session keys: time-bounded, target/selector-scoped, ETH-budgeted
+///         temporary signers driven through the wallet's module system.
+contract SessionKeyModuleTest is Helper {
+  SessionKeyModule internal module;
+  MockSessionTarget internal target;
+  address internal sessionKey;
+  uint48 internal constant SESSION_TTL = 1 days;
+  uint256 internal constant SESSION_BUDGET = 1 ether;
+
+  function setUp() public {
+    initialize_helper(LOG_LEVEL, TestType.TestWithoutFactory_extended);
+    module = new SessionKeyModule();
+    target = new MockSessionTarget();
+    sessionKey = vm.addr(777);
+    vm.deal(address(myMultiSig), 10 ether);
+
+    _execFromWallet(address(myMultiSig), abi.encodeWithSignature('enableModule(address)', address(module)));
+    assertTrue(myMultiSigExtended.isModule(address(module)));
+  }
+
+  function _ownersPk() internal view returns (uint256[] memory pks) {
+    pks = new uint256[](2);
+    pks[0] = OWNERS_PK[0];
+    pks[1] = OWNERS_PK[1];
+  }
+
+  /// @dev Gas forwarded to the inner call of wallet-driven execs. Granting a
+  ///      session key writes several cold storage slots, so it needs more
+  ///      than the suite-wide `DEFAULT_GAS`.
+  uint256 internal constant EXEC_GAS = 300_000;
+
+  /// @dev Threshold-signed `execTransaction` from the wallet to `to_`.
+  function _execFromWallet(address to_, bytes memory data_) internal {
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      to_,
+      0,
+      data_,
+      EXEC_GAS,
+      build_signatures(myMultiSig, _ownersPk(), to_, 0, data_, EXEC_GAS)
+    );
+  }
+
+  function _grant(address key, uint48 validAfter, uint48 validUntil, uint256 budget, address[] memory targets, bytes4[] memory selectors) internal {
+    _execFromWallet(
+      address(module),
+      abi.encodeCall(module.grantSessionKey, (key, validAfter, validUntil, budget, targets, selectors))
+    );
+  }
+
+  function _defaultGrant() internal {
+    address[] memory targets = new address[](1);
+    targets[0] = address(target);
+    _grant(sessionKey, 0, uint48(block.timestamp) + SESSION_TTL, SESSION_BUDGET, targets, new bytes4[](0));
+  }
+
+  // ---------- grant ----------
+
+  function test_grant_requires_wallet_threshold_path() public {
+    // Granting is not gated inside the module itself — the grant is scoped
+    // to `msg.sender` as the wallet. A grant recorded by a random EOA only
+    // creates keys for that EOA-as-wallet, never for the multisig.
+    address[] memory targets = new address[](1);
+    targets[0] = address(target);
+    vm.prank(NOT_OWNERS[0]);
+    module.grantSessionKey(sessionKey, 0, uint48(block.timestamp) + SESSION_TTL, SESSION_BUDGET, targets, new bytes4[](0));
+    assertFalse(module.isSessionKeyActive(address(myMultiSig), sessionKey));
+  }
+
+  function test_grant_records_scope_window_and_budget() public {
+    _defaultGrant();
+    assertTrue(module.isSessionKeyActive(address(myMultiSig), sessionKey));
+    assertTrue(module.isSessionTargetAllowed(address(myMultiSig), sessionKey, address(target)));
+    assertFalse(module.isSessionTargetAllowed(address(myMultiSig), sessionKey, NOT_OWNERS[0]));
+    // No selector restriction: any selector is allowed.
+    assertTrue(module.isSessionSelectorAllowed(address(myMultiSig), sessionKey, MockSessionTarget.ping.selector));
+    assertEq(module.sessionBudgetRemaining(address(myMultiSig), sessionKey), SESSION_BUDGET);
+  }
+
+  function test_grant_rejects_wallet_as_target() public {
+    address[] memory targets = new address[](1);
+    targets[0] = address(myMultiSig);
+    bytes memory data = abi.encodeCall(
+      module.grantSessionKey,
+      (sessionKey, 0, uint48(block.timestamp) + SESSION_TTL, SESSION_BUDGET, targets, new bytes4[](0))
+    );
+    bytes memory signatures = build_signatures(myMultiSig, _ownersPk(), address(module), 0, data, EXEC_GAS);
+    uint96 nonce = myMultiSig.nonce();
+    // The wallet bubbles the module's revert payload out of execTransaction.
+    vm.prank(OWNERS[0]);
+    vm.expectRevert(abi.encodeWithSignature('SessionKeyTargetIsWallet()'));
+    myMultiSigExtended.execTransaction(address(module), 0, data, EXEC_GAS, nonce, 0, 0, signatures);
+  }
+
+  function test_grant_rejects_bad_window_and_empty_targets() public {
+    address[] memory targets = new address[](1);
+    targets[0] = address(target);
+    vm.startPrank(NOT_OWNERS[1]);
+    vm.expectRevert(
+      abi.encodeWithSignature('SessionKeyInvalidWindow(uint48,uint48)', uint48(0), uint48(block.timestamp - 1))
+    );
+    module.grantSessionKey(sessionKey, 0, uint48(block.timestamp - 1), SESSION_BUDGET, targets, new bytes4[](0));
+    vm.expectRevert(abi.encodeWithSignature('SessionKeyNoTargets()'));
+    module.grantSessionKey(sessionKey, 0, uint48(block.timestamp) + SESSION_TTL, SESSION_BUDGET, new address[](0), new bytes4[](0));
+    vm.stopPrank();
+  }
+
+  // ---------- execute ----------
+
+  function test_execute_within_scope_and_budget_succeeds() public {
+    _defaultGrant();
+    uint96 nonceBefore = myMultiSig.nonce();
+    uint256 balanceBefore = address(target).balance;
+
+    vm.prank(sessionKey);
+    bool success = module.executeWithSessionKey(
+      address(myMultiSig),
+      address(target),
+      0.4 ether,
+      abi.encodeCall(MockSessionTarget.ping, ())
+    );
+
+    assertTrue(success);
+    assertEq(target.pings(), 1);
+    assertEq(address(target).balance - balanceBefore, 0.4 ether);
+    assertEq(module.sessionBudgetRemaining(address(myMultiSig), sessionKey), SESSION_BUDGET - 0.4 ether);
+    // Module-driven execution must not bump the wallet nonce — pending
+    // owner-signed transactions stay valid.
+    assertEq(myMultiSig.nonce(), nonceBefore);
+  }
+
+  function test_execute_over_budget_reverts() public {
+    _defaultGrant();
+    vm.startPrank(sessionKey);
+    module.executeWithSessionKey(address(myMultiSig), address(target), 0.7 ether, bytes(''));
+    vm.expectRevert(
+      abi.encodeWithSignature('SessionKeyBudgetExceeded(uint256,uint256)', 0.7 ether, 0.3 ether)
+    );
+    module.executeWithSessionKey(address(myMultiSig), address(target), 0.7 ether, bytes(''));
+    vm.stopPrank();
+  }
+
+  function test_execute_outside_time_window_reverts() public {
+    address[] memory targets = new address[](1);
+    targets[0] = address(target);
+    uint48 startsAt = uint48(block.timestamp) + 1 hours;
+    _grant(sessionKey, startsAt, startsAt + SESSION_TTL, SESSION_BUDGET, targets, new bytes4[](0));
+
+    // Too early.
+    vm.prank(sessionKey);
+    vm.expectRevert(
+      abi.encodeWithSignature('SessionKeyNotActive(address,address)', address(myMultiSig), sessionKey)
+    );
+    module.executeWithSessionKey(address(myMultiSig), address(target), 0, bytes(''));
+
+    // Inside the window.
+    vm.warp(startsAt);
+    vm.prank(sessionKey);
+    assertTrue(module.executeWithSessionKey(address(myMultiSig), address(target), 0, bytes('')));
+
+    // Expired.
+    vm.warp(startsAt + SESSION_TTL + 1);
+    vm.prank(sessionKey);
+    vm.expectRevert(
+      abi.encodeWithSignature('SessionKeyNotActive(address,address)', address(myMultiSig), sessionKey)
+    );
+    module.executeWithSessionKey(address(myMultiSig), address(target), 0, bytes(''));
+  }
+
+  function test_execute_unscoped_target_reverts() public {
+    _defaultGrant();
+    vm.prank(sessionKey);
+    vm.expectRevert(abi.encodeWithSignature('SessionKeyTargetNotAllowed(address)', NOT_OWNERS[0]));
+    module.executeWithSessionKey(address(myMultiSig), NOT_OWNERS[0], 0.1 ether, bytes(''));
+  }
+
+  function test_execute_wallet_as_target_reverts() public {
+    _defaultGrant();
+    vm.prank(sessionKey);
+    vm.expectRevert(abi.encodeWithSignature('SessionKeyCannotCallWallet()'));
+    module.executeWithSessionKey(
+      address(myMultiSig),
+      address(myMultiSig),
+      0,
+      abi.encodeWithSignature('addOwner(address)', sessionKey)
+    );
+  }
+
+  function test_selector_restriction_enforced() public {
+    address[] memory targets = new address[](1);
+    targets[0] = address(target);
+    bytes4[] memory selectors = new bytes4[](1);
+    selectors[0] = MockSessionTarget.ping.selector;
+    _grant(sessionKey, 0, uint48(block.timestamp) + SESSION_TTL, SESSION_BUDGET, targets, selectors);
+
+    vm.startPrank(sessionKey);
+    assertTrue(
+      module.executeWithSessionKey(address(myMultiSig), address(target), 0, abi.encodeCall(MockSessionTarget.ping, ()))
+    );
+    vm.expectRevert(
+      abi.encodeWithSignature('SessionKeySelectorNotAllowed(bytes4)', MockSessionTarget.pong.selector)
+    );
+    module.executeWithSessionKey(address(myMultiSig), address(target), 0, abi.encodeCall(MockSessionTarget.pong, ()));
+    // Plain ETH transfer matches the bytes4(0) sentinel, which this grant
+    // does not allow.
+    vm.expectRevert(abi.encodeWithSignature('SessionKeySelectorNotAllowed(bytes4)', bytes4(0)));
+    module.executeWithSessionKey(address(myMultiSig), address(target), 0.1 ether, bytes(''));
+    vm.stopPrank();
+  }
+
+  function test_unknown_key_cannot_execute() public {
+    _defaultGrant();
+    vm.prank(NOT_OWNERS[5]);
+    vm.expectRevert(
+      abi.encodeWithSignature('SessionKeyNotActive(address,address)', address(myMultiSig), NOT_OWNERS[5])
+    );
+    module.executeWithSessionKey(address(myMultiSig), address(target), 0, bytes(''));
+  }
+
+  // ---------- revoke ----------
+
+  function test_single_owner_can_revoke_immediately() public {
+    _defaultGrant();
+    vm.prank(OWNERS[1]);
+    module.revokeSessionKey(address(myMultiSig), sessionKey);
+    assertFalse(module.isSessionKeyActive(address(myMultiSig), sessionKey));
+    assertFalse(module.isSessionTargetAllowed(address(myMultiSig), sessionKey, address(target)));
+
+    vm.prank(sessionKey);
+    vm.expectRevert(
+      abi.encodeWithSignature('SessionKeyNotActive(address,address)', address(myMultiSig), sessionKey)
+    );
+    module.executeWithSessionKey(address(myMultiSig), address(target), 0, bytes(''));
+  }
+
+  function test_non_owner_cannot_revoke() public {
+    _defaultGrant();
+    vm.prank(NOT_OWNERS[0]);
+    vm.expectRevert(abi.encodeWithSignature('NotWalletOrOwner(address)', NOT_OWNERS[0]));
+    module.revokeSessionKey(address(myMultiSig), sessionKey);
+  }
+
+  function test_regrant_resets_budget_and_scope() public {
+    _defaultGrant();
+    vm.prank(sessionKey);
+    module.executeWithSessionKey(address(myMultiSig), address(target), 0.9 ether, bytes(''));
+    assertEq(module.sessionBudgetRemaining(address(myMultiSig), sessionKey), 0.1 ether);
+
+    // Re-grant with a different scope: budget resets, old target drops out.
+    MockSessionTarget newTarget = new MockSessionTarget();
+    address[] memory targets = new address[](1);
+    targets[0] = address(newTarget);
+    _grant(sessionKey, 0, uint48(block.timestamp) + SESSION_TTL, SESSION_BUDGET, targets, new bytes4[](0));
+
+    assertEq(module.sessionBudgetRemaining(address(myMultiSig), sessionKey), SESSION_BUDGET);
+    assertFalse(module.isSessionTargetAllowed(address(myMultiSig), sessionKey, address(target)));
+    assertTrue(module.isSessionTargetAllowed(address(myMultiSig), sessionKey, address(newTarget)));
+
+    vm.prank(sessionKey);
+    vm.expectRevert(abi.encodeWithSignature('SessionKeyTargetNotAllowed(address)', address(target)));
+    module.executeWithSessionKey(address(myMultiSig), address(target), 0, bytes(''));
+  }
+}

--- a/test/shared/tests.ts
+++ b/test/shared/tests.ts
@@ -46,10 +46,14 @@ export async function MyMultiSigStandardTests(deploymentType = DeploymentType.Si
             2,
             true,
           )
+          // Explicit gasLimit for the same reason as the direct deploys in
+          // setup.ts: wallet creation code is large under coverage
+          // instrumentation and the auto-estimator can exceed the per-tx cap.
           const tx = await deployment.contract.createMultiSig(
             Helper.CONTRACT_NAME,
             [owner01.address, owner02.address, owner03.address],
             2,
+            { gasLimit: 50_000_000 },
           )
           await tx.wait()
           const contractAddress = await deployment.contract.multiSig(0)
@@ -1161,12 +1165,17 @@ export async function MyMultiSigExtendedTests(deploymentType = DeploymentType.Si
             2,
             true,
           )
+          // Explicit gasLimit for the same reason as the direct deploys in
+          // setup.ts: the wallet creation code is large (and even larger
+          // under coverage instrumentation), so the auto-estimator can pick
+          // a number above the node's per-tx cap.
           const tx = await deployment.contract.createMyMultiSigExtended(
             Helper.CONTRACT_NAME,
             [owner01.address, owner02.address, owner03.address],
             2,
             Helper.DEFAULT_ALLOW_ONLY_OWNER,
             Helper.ENTRY_POINT_V07_ADDRESS,
+            { gasLimit: 50_000_000 },
           )
           await tx.wait()
           const contractAddress = await deployment.contract.multiSig(0)
@@ -2417,12 +2426,15 @@ export async function MyMultiSigAdvancedTests(deploymentType = DeploymentType.Si
             Helper.DEFAULT_THRESHOLD,
             true,
           )
+          // Explicit gasLimit — same per-tx-cap consideration as the other
+          // factory-driven creations above.
           const tx = await deployment.contract.createMyMultiSigAdvanced(
             Helper.CONTRACT_NAME,
             owners,
             Helper.DEFAULT_THRESHOLD,
             Helper.DEFAULT_ALLOW_ONLY_OWNER,
             Helper.ENTRY_POINT_V07_ADDRESS,
+            { gasLimit: 50_000_000 },
           )
           await tx.wait()
           const Contract = await ethers.getContractFactory(Helper.CONTRACT_NAME_EXTENDED)

--- a/test/shared/tests.ts
+++ b/test/shared/tests.ts
@@ -1062,6 +1062,63 @@ export async function MyMultiSigStandardTests(deploymentType = DeploymentType.Si
         expect(await contract.nonce()).to.equal(nonceBefore)
       })
     })
+
+    describe('signMessage - on-chain typed-data auth (EIP-1271)', function () {
+      const MAGIC = '0x1626ba7e'
+      const NOT_MAGIC = '0xffffffff'
+      // EIP-1271 verifiers pass a 32-byte digest; the stored message is
+      // its ABI encoding (Safe-compatible convention).
+      const dataHash = ethers.utils.keccak256(ethers.utils.toUtf8Bytes('siwe:login:mymultisig.app'))
+      const message = ethers.utils.defaultAbiCoder.encode(['bytes32'], [dataHash])
+
+      it('getMessageHash matches a manual EIP-712 computation', async function () {
+        const domain = {
+          name: Helper.CONTRACT_NAME,
+          version: await contract.version(),
+          chainId: (await ethers.provider.getNetwork()).chainId,
+          verifyingContract: contract.address,
+        }
+        const types = { MyMultiSigMessage: [{ name: 'message', type: 'bytes' }] }
+        const expected = ethers.utils._TypedDataEncoder.hash(domain, types, { message })
+        expect(await contract.getMessageHash(message)).to.equal(expected)
+      })
+
+      it('signMessage requires threshold consensus (direct call reverts OnlyThisContract)', async function () {
+        await expect(contract.connect(owner01).signMessage(message)).to.be.revertedWithCustomError(
+          contract,
+          'OnlyThisContract',
+        )
+      })
+
+      it('signMessage flips the empty-signature EIP-1271 path to the magic value', async function () {
+        expect(await contract['isValidSignature(bytes32,bytes)'](dataHash, '0x')).to.equal(NOT_MAGIC)
+        const receipt = await Helper.execOnlyThis(contract, owner01, [owner01, owner02], 'signMessage', [message])
+        const events = await Helper.getEventFromReceipt(contract, receipt)
+        expect(events.find((e: any) => e && e.name === 'MessageSigned')).to.not.equal(undefined)
+        expect(await contract.isMessageSigned(await contract.getMessageHash(message))).to.be.true
+        expect(await contract['isValidSignature(bytes32,bytes)'](dataHash, '0x')).to.equal(MAGIC)
+      })
+
+      it('unsignMessage withdraws the approval', async function () {
+        await Helper.execOnlyThis(contract, owner01, [owner01, owner02], 'signMessage', [message])
+        expect(await contract['isValidSignature(bytes32,bytes)'](dataHash, '0x')).to.equal(MAGIC)
+        const receipt = await Helper.execOnlyThis(contract, owner01, [owner01, owner02], 'unsignMessage', [message])
+        const events = await Helper.getEventFromReceipt(contract, receipt)
+        expect(events.find((e: any) => e && e.name === 'MessageUnsigned')).to.not.equal(undefined)
+        expect(await contract.isMessageSigned(await contract.getMessageHash(message))).to.be.false
+        expect(await contract['isValidSignature(bytes32,bytes)'](dataHash, '0x')).to.equal(NOT_MAGIC)
+      })
+
+      it('a signed message never validates on a sibling wallet (domain-bound)', async function () {
+        await Helper.execOnlyThis(contract, owner01, [owner01, owner02], 'signMessage', [message])
+        const sibling = await Helper.setupContract(Helper.CONTRACT_NAME, [
+          owner01.address,
+          owner02.address,
+          owner03.address,
+        ])
+        expect(await sibling.contract['isValidSignature(bytes32,bytes)'](dataHash, '0x')).to.equal(NOT_MAGIC)
+      })
+    })
   })
 }
 
@@ -2696,6 +2753,118 @@ export async function MyMultiSigAdvancedTests(deploymentType = DeploymentType.Si
         await expect(
           contract.connect(owner01).execTransactionFromModule(user01.address, 0, '0x', 0),
         ).to.be.revertedWithCustomError(contract, 'NotAModule')
+      })
+    })
+
+    // -- Session keys (module-driven temporary signers) ---------------------
+    describe('Session keys (SessionKeyModule)', function () {
+      let module: any
+      // Granting writes several cold storage slots — needs more than the
+      // suite-wide DEFAULT_GAS for the inner call.
+      const EXEC_GAS = 300000
+      const DAY = 24 * 60 * 60
+
+      const grantSessionKey = async (key: string, validUntil: number, budget: any, targets: string[]) => {
+        const data = module.interface.encodeFunctionData('grantSessionKey', [
+          key,
+          0,
+          validUntil,
+          budget,
+          targets,
+          [],
+        ]) as `0x${string}`
+        await Helper.execTransaction(
+          contract,
+          owner01,
+          [owner01, owner02],
+          module.address,
+          Helper.ZERO,
+          data,
+          EXEC_GAS,
+        )
+      }
+
+      beforeEach(async function () {
+        const Module = await ethers.getContractFactory('SessionKeyModule')
+        module = await (await Module.deploy()).deployed()
+        await Helper.enableModule(contract, owner01, [owner01, owner02], module.address)
+      })
+
+      it('granted key executes within scope and budget; wallet nonce untouched', async function () {
+        const now = (await ethers.provider.getBlock('latest')).timestamp
+        await grantSessionKey(user01.address, now + DAY, ethers.utils.parseEther('1'), [user02.address])
+        expect(await module.isSessionKeyActive(contract.address, user01.address)).to.be.true
+
+        const nonceBefore = await contract.nonce()
+        const balanceBefore = await ethers.provider.getBalance(user02.address)
+        await (
+          await module
+            .connect(user01)
+            .executeWithSessionKey(contract.address, user02.address, ethers.utils.parseEther('0.4'), '0x')
+        ).wait()
+        const balanceAfter = await ethers.provider.getBalance(user02.address)
+        expect(balanceAfter.sub(balanceBefore)).to.equal(ethers.utils.parseEther('0.4'))
+        expect(await module.sessionBudgetRemaining(contract.address, user01.address)).to.equal(
+          ethers.utils.parseEther('0.6'),
+        )
+        // Module-driven execution must not bump the wallet nonce.
+        expect(await contract.nonce()).to.equal(nonceBefore)
+      })
+
+      it('rejects out-of-scope targets and over-budget spends', async function () {
+        const now = (await ethers.provider.getBlock('latest')).timestamp
+        await grantSessionKey(user01.address, now + DAY, ethers.utils.parseEther('1'), [user02.address])
+
+        await expect(
+          module
+            .connect(user01)
+            .executeWithSessionKey(contract.address, user03.address, ethers.utils.parseEther('0.1'), '0x'),
+        ).to.be.revertedWithCustomError(module, 'SessionKeyTargetNotAllowed')
+        await expect(
+          module
+            .connect(user01)
+            .executeWithSessionKey(contract.address, user02.address, ethers.utils.parseEther('1.1'), '0x'),
+        ).to.be.revertedWithCustomError(module, 'SessionKeyBudgetExceeded')
+      })
+
+      it('a session key can never call the wallet itself', async function () {
+        const now = (await ethers.provider.getBlock('latest')).timestamp
+        await grantSessionKey(user01.address, now + DAY, ethers.utils.parseEther('1'), [user02.address])
+        await expect(
+          module
+            .connect(user01)
+            .executeWithSessionKey(
+              contract.address,
+              contract.address,
+              Helper.ZERO,
+              contract.interface.encodeFunctionData('addOwner(address)', [user01.address]),
+            ),
+        ).to.be.revertedWithCustomError(module, 'SessionKeyCannotCallWallet')
+      })
+
+      it('expires after the time window', async function () {
+        const now = (await ethers.provider.getBlock('latest')).timestamp
+        await grantSessionKey(user01.address, now + DAY, ethers.utils.parseEther('1'), [user02.address])
+        await Helper.advanceTime(DAY + 1)
+        expect(await module.isSessionKeyActive(contract.address, user01.address)).to.be.false
+        await expect(
+          module.connect(user01).executeWithSessionKey(contract.address, user02.address, Helper.ZERO, '0x'),
+        ).to.be.revertedWithCustomError(module, 'SessionKeyNotActive')
+      })
+
+      it('any single owner can revoke immediately; non-owners cannot', async function () {
+        const now = (await ethers.provider.getBlock('latest')).timestamp
+        await grantSessionKey(user01.address, now + DAY, ethers.utils.parseEther('1'), [user02.address])
+
+        await expect(module.connect(user03).revokeSessionKey(contract.address, user01.address)).to.be.revertedWithCustomError(
+          module,
+          'NotWalletOrOwner',
+        )
+        await (await module.connect(owner02).revokeSessionKey(contract.address, user01.address)).wait()
+        expect(await module.isSessionKeyActive(contract.address, user01.address)).to.be.false
+        await expect(
+          module.connect(user01).executeWithSessionKey(contract.address, user02.address, Helper.ZERO, '0x'),
+        ).to.be.revertedWithCustomError(module, 'SessionKeyNotActive')
       })
     })
 

--- a/types/MyMultiSig.ts
+++ b/types/MyMultiSig.ts
@@ -38,8 +38,10 @@ export interface MyMultiSigInterface extends utils.Interface {
     "execTransaction(address,uint256,bytes,uint256,bytes)": FunctionFragment;
     "generateHash(address,uint256,bytes,uint256,uint256,uint256)": FunctionFragment;
     "getApprovedOwners(bytes32)": FunctionFragment;
+    "getMessageHash(bytes)": FunctionFragment;
     "getThreshold(bytes32)": FunctionFragment;
     "incrementNonce()": FunctionFragment;
+    "isMessageSigned(bytes32)": FunctionFragment;
     "isOwner(address)": FunctionFragment;
     "isValidSignature(bytes32,bytes)": FunctionFragment;
     "isValidSignature(address,uint256,bytes,uint256,uint256,uint256,bytes)": FunctionFragment;
@@ -54,8 +56,10 @@ export interface MyMultiSigInterface extends utils.Interface {
     "removeOwner(address)": FunctionFragment;
     "replaceOwner(address,address)": FunctionFragment;
     "revokeApproval(bytes32)": FunctionFragment;
+    "signMessage(bytes)": FunctionFragment;
     "supportsInterface(bytes4)": FunctionFragment;
     "threshold()": FunctionFragment;
+    "unsignMessage(bytes)": FunctionFragment;
     "version()": FunctionFragment;
   };
 
@@ -69,8 +73,10 @@ export interface MyMultiSigInterface extends utils.Interface {
       | "execTransaction(address,uint256,bytes,uint256,bytes)"
       | "generateHash"
       | "getApprovedOwners"
+      | "getMessageHash"
       | "getThreshold"
       | "incrementNonce"
+      | "isMessageSigned"
       | "isOwner"
       | "isValidSignature(bytes32,bytes)"
       | "isValidSignature(address,uint256,bytes,uint256,uint256,uint256,bytes)"
@@ -85,8 +91,10 @@ export interface MyMultiSigInterface extends utils.Interface {
       | "removeOwner"
       | "replaceOwner"
       | "revokeApproval"
+      | "signMessage"
       | "supportsInterface"
       | "threshold"
+      | "unsignMessage"
       | "version"
   ): FunctionFragment;
 
@@ -143,12 +151,20 @@ export interface MyMultiSigInterface extends utils.Interface {
     values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
+    functionFragment: "getMessageHash",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
     functionFragment: "getThreshold",
     values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
     functionFragment: "incrementNonce",
     values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "isMessageSigned",
+    values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
     functionFragment: "isOwner",
@@ -236,10 +252,18 @@ export interface MyMultiSigInterface extends utils.Interface {
     values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
+    functionFragment: "signMessage",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
     functionFragment: "supportsInterface",
     values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(functionFragment: "threshold", values?: undefined): string;
+  encodeFunctionData(
+    functionFragment: "unsignMessage",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
   encodeFunctionData(functionFragment: "version", values?: undefined): string;
 
   decodeFunctionResult(functionFragment: "addOwner", data: BytesLike): Result;
@@ -272,11 +296,19 @@ export interface MyMultiSigInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
+    functionFragment: "getMessageHash",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "getThreshold",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
     functionFragment: "incrementNonce",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "isMessageSigned",
     data: BytesLike
   ): Result;
   decodeFunctionResult(functionFragment: "isOwner", data: BytesLike): Result;
@@ -324,16 +356,26 @@ export interface MyMultiSigInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
+    functionFragment: "signMessage",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "supportsInterface",
     data: BytesLike
   ): Result;
   decodeFunctionResult(functionFragment: "threshold", data: BytesLike): Result;
+  decodeFunctionResult(
+    functionFragment: "unsignMessage",
+    data: BytesLike
+  ): Result;
   decodeFunctionResult(functionFragment: "version", data: BytesLike): Result;
 
   events: {
     "ApproveHash(address,bytes32)": EventFragment;
     "ContractEndOfLife(uint256)": EventFragment;
     "EIP712DomainChanged()": EventFragment;
+    "MessageSigned(bytes32)": EventFragment;
+    "MessageUnsigned(bytes32)": EventFragment;
     "MultiRequestExecuted(uint256,bool[],bytes[])": EventFragment;
     "OwnerAdded(address)": EventFragment;
     "OwnerRemoved(address)": EventFragment;
@@ -346,6 +388,8 @@ export interface MyMultiSigInterface extends utils.Interface {
   getEvent(nameOrSignatureOrTopic: "ApproveHash"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "ContractEndOfLife"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "EIP712DomainChanged"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "MessageSigned"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "MessageUnsigned"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "MultiRequestExecuted"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OwnerAdded"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OwnerRemoved"): EventFragment;
@@ -385,6 +429,23 @@ export type EIP712DomainChangedEvent = TypedEvent<
 
 export type EIP712DomainChangedEventFilter =
   TypedEventFilter<EIP712DomainChangedEvent>;
+
+export interface MessageSignedEventObject {
+  msgHash: string;
+}
+export type MessageSignedEvent = TypedEvent<[string], MessageSignedEventObject>;
+
+export type MessageSignedEventFilter = TypedEventFilter<MessageSignedEvent>;
+
+export interface MessageUnsignedEventObject {
+  msgHash: string;
+}
+export type MessageUnsignedEvent = TypedEvent<
+  [string],
+  MessageUnsignedEventObject
+>;
+
+export type MessageUnsignedEventFilter = TypedEventFilter<MessageUnsignedEvent>;
 
 export interface MultiRequestExecutedEventObject {
   txNonce: BigNumber;
@@ -557,6 +618,11 @@ export interface MyMultiSig extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
+    getMessageHash(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[string]>;
+
     getThreshold(
       arg0: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
@@ -565,6 +631,11 @@ export interface MyMultiSig extends BaseContract {
     incrementNonce(
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
+
+    isMessageSigned(
+      msgHash: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[boolean]>;
 
     isOwner(
       owner: PromiseOrValue<string>,
@@ -652,12 +723,22 @@ export interface MyMultiSig extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
+    signMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
     supportsInterface(
       interfaceId: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<[boolean]>;
 
     threshold(overrides?: CallOverrides): Promise<[number]>;
+
+    unsignMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
 
     version(overrides?: CallOverrides): Promise<[string]>;
   };
@@ -725,6 +806,11 @@ export interface MyMultiSig extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
+  getMessageHash(
+    message: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   getThreshold(
     arg0: PromiseOrValue<BytesLike>,
     overrides?: CallOverrides
@@ -733,6 +819,11 @@ export interface MyMultiSig extends BaseContract {
   incrementNonce(
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
+
+  isMessageSigned(
+    msgHash: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<boolean>;
 
   isOwner(
     owner: PromiseOrValue<string>,
@@ -820,12 +911,22 @@ export interface MyMultiSig extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  signMessage(
+    message: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
   supportsInterface(
     interfaceId: PromiseOrValue<BytesLike>,
     overrides?: CallOverrides
   ): Promise<boolean>;
 
   threshold(overrides?: CallOverrides): Promise<number>;
+
+  unsignMessage(
+    message: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
 
   version(overrides?: CallOverrides): Promise<string>;
 
@@ -893,12 +994,22 @@ export interface MyMultiSig extends BaseContract {
       overrides?: CallOverrides
     ): Promise<string[]>;
 
+    getMessageHash(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
     getThreshold(
       arg0: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
     incrementNonce(overrides?: CallOverrides): Promise<void>;
+
+    isMessageSigned(
+      msgHash: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<boolean>;
 
     isOwner(
       owner: PromiseOrValue<string>,
@@ -988,12 +1099,22 @@ export interface MyMultiSig extends BaseContract {
       overrides?: CallOverrides
     ): Promise<void>;
 
+    signMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
     supportsInterface(
       interfaceId: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<boolean>;
 
     threshold(overrides?: CallOverrides): Promise<number>;
+
+    unsignMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<void>;
 
     version(overrides?: CallOverrides): Promise<string>;
   };
@@ -1017,6 +1138,20 @@ export interface MyMultiSig extends BaseContract {
 
     "EIP712DomainChanged()"(): EIP712DomainChangedEventFilter;
     EIP712DomainChanged(): EIP712DomainChangedEventFilter;
+
+    "MessageSigned(bytes32)"(
+      msgHash?: PromiseOrValue<BytesLike> | null
+    ): MessageSignedEventFilter;
+    MessageSigned(
+      msgHash?: PromiseOrValue<BytesLike> | null
+    ): MessageSignedEventFilter;
+
+    "MessageUnsigned(bytes32)"(
+      msgHash?: PromiseOrValue<BytesLike> | null
+    ): MessageUnsignedEventFilter;
+    MessageUnsigned(
+      msgHash?: PromiseOrValue<BytesLike> | null
+    ): MessageUnsignedEventFilter;
 
     "MultiRequestExecuted(uint256,bool[],bytes[])"(
       txNonce?: PromiseOrValue<BigNumberish> | null,
@@ -1146,6 +1281,11 @@ export interface MyMultiSig extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
+    getMessageHash(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     getThreshold(
       arg0: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
@@ -1153,6 +1293,11 @@ export interface MyMultiSig extends BaseContract {
 
     incrementNonce(
       overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    isMessageSigned(
+      msgHash: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
     ): Promise<BigNumber>;
 
     isOwner(
@@ -1241,12 +1386,22 @@ export interface MyMultiSig extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
+    signMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
     supportsInterface(
       interfaceId: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
     threshold(overrides?: CallOverrides): Promise<BigNumber>;
+
+    unsignMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
 
     version(overrides?: CallOverrides): Promise<BigNumber>;
   };
@@ -1303,6 +1458,11 @@ export interface MyMultiSig extends BaseContract {
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
+    getMessageHash(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
     getThreshold(
       arg0: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
@@ -1310,6 +1470,11 @@ export interface MyMultiSig extends BaseContract {
 
     incrementNonce(
       overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    isMessageSigned(
+      msgHash: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
     isOwner(
@@ -1398,12 +1563,22 @@ export interface MyMultiSig extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
+    signMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
     supportsInterface(
       interfaceId: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
     threshold(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
+    unsignMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
 
     version(overrides?: CallOverrides): Promise<PopulatedTransaction>;
   };

--- a/types/MyMultiSigExtended.ts
+++ b/types/MyMultiSigExtended.ts
@@ -104,10 +104,12 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     "generateHash(address,uint256,bytes,uint256,uint256,uint256)": FunctionFragment;
     "generateHashOp(address,uint256,bytes,uint256,uint256,uint256,uint8)": FunctionFragment;
     "getApprovedOwners(bytes32)": FunctionFragment;
+    "getMessageHash(bytes)": FunctionFragment;
     "getModules()": FunctionFragment;
     "getThreshold(bytes32)": FunctionFragment;
     "guard()": FunctionFragment;
     "incrementNonce()": FunctionFragment;
+    "isMessageSigned(bytes32)": FunctionFragment;
     "isModule(address)": FunctionFragment;
     "isNonceUsed(uint256)": FunctionFragment;
     "isOwner(address)": FunctionFragment;
@@ -144,11 +146,13 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     "setSensitiveValueThreshold(uint256)": FunctionFragment;
     "setTimelockDelay(uint256)": FunctionFragment;
     "setTransferInactiveOwnershipAfter(uint256)": FunctionFragment;
+    "signMessage(bytes)": FunctionFragment;
     "spendingLimitRemaining(address)": FunctionFragment;
     "supportsInterface(bytes4)": FunctionFragment;
     "takeOverOwnership(address)": FunctionFragment;
     "threshold()": FunctionFragment;
     "timelockDelay()": FunctionFragment;
+    "unsignMessage(bytes)": FunctionFragment;
     "validateUserOp((address,uint256,bytes,bytes,bytes32,uint256,bytes32,bytes,bytes),bytes32,uint256)": FunctionFragment;
     "version()": FunctionFragment;
   };
@@ -181,10 +185,12 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
       | "generateHash"
       | "generateHashOp"
       | "getApprovedOwners"
+      | "getMessageHash"
       | "getModules"
       | "getThreshold"
       | "guard"
       | "incrementNonce"
+      | "isMessageSigned"
       | "isModule"
       | "isNonceUsed"
       | "isOwner"
@@ -221,11 +227,13 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
       | "setSensitiveValueThreshold"
       | "setTimelockDelay"
       | "setTransferInactiveOwnershipAfter"
+      | "signMessage"
       | "spendingLimitRemaining"
       | "supportsInterface"
       | "takeOverOwnership"
       | "threshold"
       | "timelockDelay"
+      | "unsignMessage"
       | "validateUserOp"
       | "version"
   ): FunctionFragment;
@@ -422,6 +430,10 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
+    functionFragment: "getMessageHash",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
     functionFragment: "getModules",
     values?: undefined
   ): string;
@@ -433,6 +445,10 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
   encodeFunctionData(
     functionFragment: "incrementNonce",
     values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "isMessageSigned",
+    values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
     functionFragment: "isModule",
@@ -629,6 +645,10 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     values: [PromiseOrValue<BigNumberish>]
   ): string;
   encodeFunctionData(
+    functionFragment: "signMessage",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
     functionFragment: "spendingLimitRemaining",
     values: [PromiseOrValue<string>]
   ): string;
@@ -644,6 +664,10 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
   encodeFunctionData(
     functionFragment: "timelockDelay",
     values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "unsignMessage",
+    values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
     functionFragment: "validateUserOp",
@@ -756,6 +780,10 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     functionFragment: "getApprovedOwners",
     data: BytesLike
   ): Result;
+  decodeFunctionResult(
+    functionFragment: "getMessageHash",
+    data: BytesLike
+  ): Result;
   decodeFunctionResult(functionFragment: "getModules", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "getThreshold",
@@ -764,6 +792,10 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
   decodeFunctionResult(functionFragment: "guard", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "incrementNonce",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "isMessageSigned",
     data: BytesLike
   ): Result;
   decodeFunctionResult(functionFragment: "isModule", data: BytesLike): Result;
@@ -890,6 +922,10 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
+    functionFragment: "signMessage",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "spendingLimitRemaining",
     data: BytesLike
   ): Result;
@@ -907,6 +943,10 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
+    functionFragment: "unsignMessage",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "validateUserOp",
     data: BytesLike
   ): Result;
@@ -919,6 +959,8 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     "DailySpendingLimitSet(address,uint256)": EventFragment;
     "EIP712DomainChanged()": EventFragment;
     "GuardSet(address)": EventFragment;
+    "MessageSigned(bytes32)": EventFragment;
+    "MessageUnsigned(bytes32)": EventFragment;
     "ModuleDisabled(address)": EventFragment;
     "ModuleEnabled(address)": EventFragment;
     "ModuleTransactionExecuted(address,address,uint256,bytes,uint256,bool)": EventFragment;
@@ -947,6 +989,8 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
   getEvent(nameOrSignatureOrTopic: "DailySpendingLimitSet"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "EIP712DomainChanged"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "GuardSet"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "MessageSigned"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "MessageUnsigned"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "ModuleDisabled"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "ModuleEnabled"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "ModuleTransactionExecuted"): EventFragment;
@@ -1034,6 +1078,23 @@ export interface GuardSetEventObject {
 export type GuardSetEvent = TypedEvent<[string], GuardSetEventObject>;
 
 export type GuardSetEventFilter = TypedEventFilter<GuardSetEvent>;
+
+export interface MessageSignedEventObject {
+  msgHash: string;
+}
+export type MessageSignedEvent = TypedEvent<[string], MessageSignedEventObject>;
+
+export type MessageSignedEventFilter = TypedEventFilter<MessageSignedEvent>;
+
+export interface MessageUnsignedEventObject {
+  msgHash: string;
+}
+export type MessageUnsignedEvent = TypedEvent<
+  [string],
+  MessageUnsignedEventObject
+>;
+
+export type MessageUnsignedEventFilter = TypedEventFilter<MessageUnsignedEvent>;
 
 export interface ModuleDisabledEventObject {
   module: string;
@@ -1497,6 +1558,11 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]]>;
 
+    getMessageHash(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[string]>;
+
     getModules(
       overrides?: CallOverrides
     ): Promise<[string[]] & { modules: string[] }>;
@@ -1511,6 +1577,11 @@ export interface MyMultiSigExtended extends BaseContract {
     incrementNonce(
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
+
+    isMessageSigned(
+      msgHash: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[boolean]>;
 
     isModule(
       module: PromiseOrValue<string>,
@@ -1719,6 +1790,11 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
+    signMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
     spendingLimitRemaining(
       owner: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -1737,6 +1813,11 @@ export interface MyMultiSigExtended extends BaseContract {
     threshold(overrides?: CallOverrides): Promise<[number]>;
 
     timelockDelay(overrides?: CallOverrides): Promise<[BigNumber]>;
+
+    unsignMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
 
     validateUserOp(
       userOp: PackedUserOperationStruct,
@@ -1939,6 +2020,11 @@ export interface MyMultiSigExtended extends BaseContract {
     overrides?: CallOverrides
   ): Promise<string[]>;
 
+  getMessageHash(
+    message: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   getModules(overrides?: CallOverrides): Promise<string[]>;
 
   getThreshold(
@@ -1951,6 +2037,11 @@ export interface MyMultiSigExtended extends BaseContract {
   incrementNonce(
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
+
+  isMessageSigned(
+    msgHash: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<boolean>;
 
   isModule(
     module: PromiseOrValue<string>,
@@ -2159,6 +2250,11 @@ export interface MyMultiSigExtended extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  signMessage(
+    message: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
   spendingLimitRemaining(
     owner: PromiseOrValue<string>,
     overrides?: CallOverrides
@@ -2177,6 +2273,11 @@ export interface MyMultiSigExtended extends BaseContract {
   threshold(overrides?: CallOverrides): Promise<number>;
 
   timelockDelay(overrides?: CallOverrides): Promise<BigNumber>;
+
+  unsignMessage(
+    message: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
 
   validateUserOp(
     userOp: PackedUserOperationStruct,
@@ -2379,6 +2480,11 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: CallOverrides
     ): Promise<string[]>;
 
+    getMessageHash(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
     getModules(overrides?: CallOverrides): Promise<string[]>;
 
     getThreshold(
@@ -2389,6 +2495,11 @@ export interface MyMultiSigExtended extends BaseContract {
     guard(overrides?: CallOverrides): Promise<string>;
 
     incrementNonce(overrides?: CallOverrides): Promise<void>;
+
+    isMessageSigned(
+      msgHash: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<boolean>;
 
     isModule(
       module: PromiseOrValue<string>,
@@ -2599,6 +2710,11 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: CallOverrides
     ): Promise<void>;
 
+    signMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
     spendingLimitRemaining(
       owner: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -2617,6 +2733,11 @@ export interface MyMultiSigExtended extends BaseContract {
     threshold(overrides?: CallOverrides): Promise<number>;
 
     timelockDelay(overrides?: CallOverrides): Promise<BigNumber>;
+
+    unsignMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<void>;
 
     validateUserOp(
       userOp: PackedUserOperationStruct,
@@ -2670,6 +2791,20 @@ export interface MyMultiSigExtended extends BaseContract {
       guard?: PromiseOrValue<string> | null
     ): GuardSetEventFilter;
     GuardSet(guard?: PromiseOrValue<string> | null): GuardSetEventFilter;
+
+    "MessageSigned(bytes32)"(
+      msgHash?: PromiseOrValue<BytesLike> | null
+    ): MessageSignedEventFilter;
+    MessageSigned(
+      msgHash?: PromiseOrValue<BytesLike> | null
+    ): MessageSignedEventFilter;
+
+    "MessageUnsigned(bytes32)"(
+      msgHash?: PromiseOrValue<BytesLike> | null
+    ): MessageUnsignedEventFilter;
+    MessageUnsigned(
+      msgHash?: PromiseOrValue<BytesLike> | null
+    ): MessageUnsignedEventFilter;
 
     "ModuleDisabled(address)"(
       module?: PromiseOrValue<string> | null
@@ -3064,6 +3199,11 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
+    getMessageHash(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     getModules(overrides?: CallOverrides): Promise<BigNumber>;
 
     getThreshold(
@@ -3075,6 +3215,11 @@ export interface MyMultiSigExtended extends BaseContract {
 
     incrementNonce(
       overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    isMessageSigned(
+      msgHash: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
     ): Promise<BigNumber>;
 
     isModule(
@@ -3284,6 +3429,11 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
+    signMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
     spendingLimitRemaining(
       owner: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -3302,6 +3452,11 @@ export interface MyMultiSigExtended extends BaseContract {
     threshold(overrides?: CallOverrides): Promise<BigNumber>;
 
     timelockDelay(overrides?: CallOverrides): Promise<BigNumber>;
+
+    unsignMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
 
     validateUserOp(
       userOp: PackedUserOperationStruct,
@@ -3499,6 +3654,11 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
+    getMessageHash(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
     getModules(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     getThreshold(
@@ -3510,6 +3670,11 @@ export interface MyMultiSigExtended extends BaseContract {
 
     incrementNonce(
       overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    isMessageSigned(
+      msgHash: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
 
     isModule(
@@ -3721,6 +3886,11 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
+    signMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
     spendingLimitRemaining(
       owner: PromiseOrValue<string>,
       overrides?: CallOverrides
@@ -3739,6 +3909,11 @@ export interface MyMultiSigExtended extends BaseContract {
     threshold(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     timelockDelay(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
+    unsignMessage(
+      message: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
 
     validateUserOp(
       userOp: PackedUserOperationStruct,


### PR DESCRIPTION
## What

Implements two features that were missing from the wallet family:

### 1. Session keys / temporary signers — `SessionKeyModule`
Time-bounded, scope-limited keys (e.g. *"can call Uniswap for 24h up to 1 ETH"*) without changing the permanent owner set.

- New standalone `contracts/modules/SessionKeyModule.sol`, riding the existing v0.4.0 module system (`execTransactionFromModule`). One deployed instance serves any number of wallets; each wallet opts in with `enableModule` + `grantSessionKey`, both threshold-gated.
- Every grant is bounded on three axes: a `[validAfter, validUntil]` time window, a mandatory target allowlist plus optional selector allowlist, and a cumulative ETH budget (charged before the inner call, refunded on failure, so reentrancy can never overspend).
- A session key can **never** call the wallet itself, so it cannot reach `addOwner` / `changeThreshold` / any `onlyThis` admin surface. The wallet's guard + allowlist gates still run inside `execTransactionFromModule`, and the wallet nonce is untouched (pending owner-signed txs stay valid).
- Revocation is cheaper than granting: the wallet **or any single current owner** can revoke immediately — a leaked key must not stay live while a quorum assembles.
- Scope entries are keyed by a per-grant epoch, so re-grants/revokes orphan old scope in O(1).
- Implemented as a module (not in-wallet) because `MyMultiSigExtended` had only ~1.2KB of EIP-170 headroom; it still fits at 24,021/24,576 bytes after this PR.

### 2. `signMessage` / typed-data for off-chain auth (EIP-1271)
Separate from tx execution: the wallet proves control off-chain with full threshold consensus.

- `signMessage(bytes)` (`onlyThis`, i.e. threshold-signed) stores the EIP-712 message hash under the new `MyMultiSigMessage(bytes message)` typehash — domain-bound, so a signed message never replays against a sibling wallet.
- EIP-1271 `isValidSignature(dataHash, "")` — **empty signature** — now returns the magic value when the wallet pre-signed `abi.encode(dataHash)`, matching Safe's pre-signed-message convention (SIWE, order books, ownership attestations).
- `unsignMessage` withdraws the approval; `getMessageHash` / `isMessageSigned` views for integrators.
- The existing threshold-signature EIP-1271 path is byte-for-byte unchanged (purely additive).

## Tests

- Foundry: `MyMultiSig.signMessage.t.sol` (7 tests) + `SessionKeyModule.t.sol` (14 tests) — full suite 139 passed.
- Hardhat: new `signMessage` describe in the standard suite and `Session keys` describe in the advanced suite, each running for direct and factory deployments — full suite 293 passing.
- `forge build --sizes`: `MyMultiSigExtended` 24,021 B runtime (555 B margin under EIP-170).
- Committed types regenerated with `yarn build` (module types are intentionally not exported — the build script only exports `MyMultiSig*` artifacts, same as `ITransactionGuard`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)