### PR TITLE
fix(wallet): allowance signature replay — consume the nonce

### DIFF
--- a/contracts/MyMultiSigExtended.sol
+++ b/contracts/MyMultiSigExtended.sol
@@ -556,7 +556,9 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   ///         do NOT burn the cap.
   /// @dev    Re-uses the same EIP-712 typehash as `execTransaction`. Bound
   ///         to the same `(to, value, data, gas, nonce = _txnNonce,
-  ///         validUntil)` fields.
+  ///         validUntil)` fields. Bumps `_txnNonce` once the signature
+  ///         validates, so each signature is single-use — even when the
+  ///         inner call fails.
   function execTransactionWithSpendingAllowance(
     address to,
     uint256 value,
@@ -572,6 +574,10 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
     bytes32 txHash = generateHashOp(to, value, data, txnGas, currentNonce, validUntil, 0);
     address recovered = _recoverSigner(signatures, txHash);
     if (recovered != msg.sender || !isOwner(recovered)) revert AllowanceRequiresSingleSigner();
+    // The hash is bound to `currentNonce`, so bumping the nonce consumes
+    // the signature. Mirrors `_execTransaction`: the bump happens right
+    // after signature validation, whether or not the inner call succeeds.
+    _bumpNonce();
     uint256 cap = _dailyLimitPerOwner[recovered];
     if (cap == 0) revert AllowanceLimitNotSet(recovered);
     _rolloverIfNeeded(recovered);
@@ -583,6 +589,7 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
     success = _runLoggedCall(to, value, data, txnGas, currentNonce, validUntil);
     // Commit-on-success: failed inner calls don't burn the cap.
     if (success) _dailySpentByOwner[recovered] += value;
+    _emitEndOfLifeIfNear();
   }
 
   /// @dev Shared tail for the timelock (`executeScheduled`) and allowance

--- a/test/shared/tests.ts
+++ b/test/shared/tests.ts
@@ -2640,6 +2640,39 @@ export async function MyMultiSigAdvancedTests(deploymentType = DeploymentType.Si
         ).to.be.revertedWithCustomError(contract, 'DailySpendingLimitExceeded')
       })
 
+      it('allowance signature is single-use: replay is rejected', async function () {
+        const cap = ethers.utils.parseEther('1')
+        await Helper.setDailySpendingLimit(contract, owner01, [owner01, owner02], owner01.address, cap)
+        const value = ethers.utils.parseEther('0.1')
+        const nonceBefore = await contract.nonce()
+        const sig = await Helper.signMultiSigTxn(
+          contract,
+          owner01,
+          user01.address,
+          value,
+          '0x',
+          Helper.DEFAULT_GAS,
+          nonceBefore,
+          0,
+        )
+        await (
+          await contract
+            .connect(owner01)
+            .execTransactionWithSpendingAllowance(user01.address, value, '0x', Helper.DEFAULT_GAS, 0, sig)
+        ).wait()
+        // The spend consumed the wallet nonce.
+        expect(await contract.nonce()).to.be.equal(nonceBefore.add(1))
+        // Replaying the exact same signature fails: the hash is now bound
+        // to the bumped nonce, so the sig no longer recovers to the sender.
+        await expect(
+          contract
+            .connect(owner01)
+            .execTransactionWithSpendingAllowance(user01.address, value, '0x', Helper.DEFAULT_GAS, 0, sig),
+        ).to.be.revertedWithCustomError(contract, 'AllowanceRequiresSingleSigner')
+        // The cap was only charged once.
+        expect(await contract.spendingLimitRemaining(owner01.address)).to.be.equal(cap.sub(value))
+      })
+
       it('day rollover resets the cap', async function () {
         const cap = ethers.utils.parseEther('1')
         await Helper.setDailySpendingLimit(contract, owner01, [owner01, owner02], owner01.address, cap)


### PR DESCRIPTION
## Problem

`execTransactionWithSpendingAllowance` computed the EIP-712 hash over the current `_txnNonce` but never bumped it (and never marked the signature consumed). The same 65-byte signature could therefore be resubmitted repeatedly until the signer's daily cap was drained — e.g. an owner signs a 0.1 ETH transfer under a 1 ETH daily cap, and anyone holding the signature (or the signer's compromised relayer) submits it 10×. After the 24h rollover the signature became valid again, so the drain repeated every day.

## Fix

Bump `_txnNonce` immediately after signature validation, mirroring the base `_execTransaction`:

- The signature is single-use whether or not the inner call succeeds (same semantics as every other exec path).
- The cap itself keeps its commit-on-success rule — a failed inner call still doesn't burn the allowance.
- The entry point now also calls `_emitEndOfLifeIfNear()`, like the other nonce-advancing exec overloads.

The ABI is unchanged, so no `types/` / `constants/` regeneration was needed.

## Tests

- New Hardhat regression test: a spent allowance signature is rejected on replay (`AllowanceRequiresSingleSigner`), the wallet nonce advances by 1, and the cap is charged only once.
- `npx hardhat test`: 295 passing; `forge test`: 139 passing.

## Notes / follow-ups (not in this PR)

While fixing this I noticed two adjacent gaps in the same entry point, both candidates for a separate PR:

1. `validUntil` is bound into the signed hash but expiry is never enforced — every other signed path reverts with `SignatureExpired` when `block.timestamp > validUntil`.
2. The path doesn't check `_noncesUsed[currentNonce]`, so `markNonceAsUsed` doesn't invalidate a pending allowance signature the way it does for `scheduleTransaction` / `executeScheduled`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)