### PR TITLE
fix(wallet): advancedFeaturesEnabled allowance bit

### DIFF
--- a/contracts/MyMultiSigExtended.sol
+++ b/contracts/MyMultiSigExtended.sol
@@ -56,6 +56,7 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   mapping(address => bool) internal _allowedTargets;
 
   // Allowance
+  bool internal _dailyLimitsEnabled; // first non-zero setDailySpendingLimit flips this on
   mapping(address => uint256) internal _dailyLimitPerOwner;
   mapping(address => uint256) internal _dailySpentByOwner;
   mapping(address => uint256) internal _lastPeriodResetByOwner;
@@ -546,6 +547,7 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
 
   function setDailySpendingLimit(address owner, uint256 limitWei) public virtual onlyThis {
     _dailyLimitPerOwner[owner] = limitWei;
+    if (limitWei > 0) _dailyLimitsEnabled = true;
     emit DailySpendingLimitSet(owner, limitWei);
   }
 
@@ -826,7 +828,7 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
     if (_timelockDelay > 0) mask |= 0x01;
     if (_guard != address(0)) mask |= 0x02;
     if (_allowedTargetsEnabled) mask |= 0x04;
-    if (_dailyLimitPerOwner[address(0)] > 0) mask |= 0x08;
+    if (_dailyLimitsEnabled) mask |= 0x08;
     if (_modulesHead != address(0)) mask |= 0x10;
   }
 

--- a/test/shared/tests.ts
+++ b/test/shared/tests.ts
@@ -2594,6 +2594,13 @@ export async function MyMultiSigAdvancedTests(deploymentType = DeploymentType.Si
 
     // -- Feature 3: Spending limits / allowance ----------------------------
     describe('Allowance (Feature 3)', function () {
+      it('advancedFeaturesEnabled sets the 0x08 bit once a daily limit is set', async function () {
+        expect(await contract.advancedFeaturesEnabled()).to.be.equal(0)
+        const cap = ethers.utils.parseEther('1')
+        await Helper.setDailySpendingLimit(contract, owner01, [owner01, owner02], owner01.address, cap)
+        expect(await contract.advancedFeaturesEnabled()).to.be.equal(0x08)
+      })
+
       it('single-signer path charges against the submitter cap', async function () {
         const cap = ethers.utils.parseEther('1')
         await Helper.setDailySpendingLimit(contract, owner01, [owner01, owner02], owner01.address, cap)


### PR DESCRIPTION
## Summary
- `advancedFeaturesEnabled()` bit `0x08` incorrectly checked `_dailyLimitPerOwner[address(0)]`, which is never written, so the allowance bit almost always stayed off.
- Adds `_dailyLimitsEnabled`, flipped on the first non-zero `setDailySpendingLimit` (same pattern as `_allowedTargetsEnabled`), and uses it for the bitmask.
- Adds a Hardhat regression covering the `0x08` bit.

## Test plan
- [x] `npx hardhat test` (297 passing)
- [x] `forge test` (139 passing)
- [ ] Confirm UI/explorer consumers of `advancedFeaturesEnabled()` show allowance as active after setting a daily limit


Made with [Cursor](https://cursor.com)