### PR TITLE
fix: make the ERC-4337 v0.7 account flow standard and portable

### DIFF
--- a/contracts/MyMultiSigExtended.sol
+++ b/contracts/MyMultiSigExtended.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
+import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 import './MyMultiSig.sol';
 import './interfaces/ITransactionGuard.sol';
 import './interfaces/IAccount.sol';
@@ -113,7 +114,6 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   // --- v0.5.0 custom errors ---
   error InvalidOperation(uint8 operation);
   error NotEntryPoint();
-  error InvalidNonce(uint256 expected, uint256 got);
   error RequiresOperationByte();
 
   // --- v0.4.0 events (v0.3.0 events live in MyMultiSig.sol) ---
@@ -924,7 +924,6 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
     uint8 operation,
     bytes reason
   );
-  event UserOpExecuted(bytes32 indexed userOpHash, uint256 indexed nonce);
 
   // --------- execTransaction overloads with operation byte ---------
 
@@ -1131,53 +1130,78 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
 
   // --------- ERC-4337 v0.7 ---------
 
-  /// @notice IAccount.validateUserOp (v0.7). Caller must be `ENTRY_POINT`;
-  ///         requires `userOp.sender == address(this)`, `operation == 0`,
-  ///         `userOp.nonce == _txnNonce`, and threshold-reached
-  ///         signatures. Returns 0 on success, 1 (`SIG_VALIDATION_FAILED`)
-  ///         on failure.
+  /// @dev Gate shared by the ERC-4337 entry points: only the pinned
+  ///      EntryPoint may call them.
+  function _requireFromEntryPoint() internal view {
+    if (msg.sender != address(ENTRY_POINT)) revert NotEntryPoint();
+  }
+
+  /// @notice The 32-byte digest the wallet's owners vote on for a UserOp:
+  ///         the EIP-191 (`personal_sign`) wrap of the EntryPoint's
+  ///         `userOpHash`. The `userOpHash` already binds the full op
+  ///         (sender, EntryPoint nonce, callData, gas fields), the
+  ///         EntryPoint address, and the chain id, so a threshold of
+  ///         votes on this digest authorizes exactly one op on one chain.
+  ///         Owners can vote off-chain (ECDSA / EIP-1271 blobs in
+  ///         `userOp.signature`, same `(owner, sig)[]` encoding as
+  ///         `execTransaction`) or on-chain via `approveHash(digest)`.
+  function userOpSigningHash(bytes32 userOpHash) public pure virtual returns (bytes32) {
+    return ECDSA.toEthSignedMessageHash(userOpHash);
+  }
+
+  /// @notice IAccount.validateUserOp (v0.7). Caller must be `ENTRY_POINT`.
+  ///         Checks a threshold of owner votes over
+  ///         `userOpSigningHash(userOpHash)` and returns 0 on success or 1
+  ///         (`SIG_VALIDATION_FAILED`) on a failed signature check, then
+  ///         transfers `missingAccountFunds` to the EntryPoint so the op's
+  ///         gas is prefunded. Replay protection lives in the EntryPoint's
+  ///         2D nonce scheme (`userOp.nonce` is validated and consumed
+  ///         there and is part of `userOpHash`); the wallet's own
+  ///         `_txnNonce` is neither read nor bumped on this path.
   function validateUserOp(
     PackedUserOperation calldata userOp,
-    bytes32 /* userOpHash */,
-    uint256 /* missingAccountFunds */
-  ) external view override returns (uint256 validationData) {
-    if (msg.sender != address(ENTRY_POINT)) revert NotEntryPoint();
-    if (userOp.sender != address(this)) revert InvalidNonce(uint256(uint160(address(this))), uint256(uint160(userOp.sender)));
+    bytes32 userOpHash,
+    uint256 missingAccountFunds
+  ) external override returns (uint256 validationData) {
+    _requireFromEntryPoint();
+    validationData = _checkSignatures(userOpSigningHash(userOpHash), 0, userOp.signature)
+      ? _SIG_VALIDATION_SUCCESS
+      : _SIG_VALIDATION_FAILED;
+    _payPrefund(missingAccountFunds);
+  }
 
-    (address to, uint256 value, bytes memory data, uint256 txnGas, uint256 validUntil, uint8 operation) =
-      _decodeUserOpCallData(userOp.callData);
-
-    if (operation != 0) revert InvalidOperation(operation);
-    uint256 expectedNonce = nonce();
-    if (userOp.nonce != expectedNonce) revert InvalidNonce(expectedNonce, userOp.nonce);
-    bytes32 txHash = generateHashOp(to, value, data, txnGas, expectedNonce, validUntil, operation);
-    if (!_checkSignaturesOp(txHash, expectedNonce, validUntil, userOp.signature)) {
-      return _SIG_VALIDATION_FAILED;
+  /// @notice ERC-4337 execution entry point. `userOp.callData` must encode
+  ///         a call to this function (`abi.encodeCall(this.execute, (to,
+  ///         value, data))`) — the EntryPoint relays it to the account
+  ///         verbatim after a successful `validateUserOp`. Runs the same
+  ///         pre-exec gates as every other exec path (timelock
+  ///         reverse-route, guard, allowlist) and bubbles the inner revert
+  ///         on failure so the EntryPoint records the op as reverted.
+  /// @param to The address the wallet calls.
+  /// @param value The wei forwarded with the call.
+  /// @param data The calldata forwarded with the call.
+  function execute(address to, uint256 value, bytes calldata data) external virtual {
+    _requireFromEntryPoint();
+    _preExecChecks(to, value, data);
+    (bool success, bytes memory returnData) = _rawCall(gasleft(), to, value, data);
+    if (!success) _revertWith(returnData);
+    address guardContract = _guard;
+    if (guardContract != address(0)) {
+      bytes32 txHash = keccak256(abi.encode(msg.sender, to, value, data, uint256(0), block.number));
+      try ITransactionGuard(guardContract).checkAfterExecution(txHash, true) {} catch (bytes memory reason) {
+        emit PostExecutionGuardFailed(guardContract, reason);
+      }
     }
-    return _SIG_VALIDATION_SUCCESS;
   }
 
-  /// @notice EntryPoint-only execution path. Reconstructs the inner call
-  ///         from `userOp.callData` and runs it through `_execExtended`.
-  function executeUserOp(PackedUserOperation calldata userOp) external payable {
-    if (msg.sender != address(ENTRY_POINT)) revert NotEntryPoint();
-
-    bytes32 userOpHash = keccak256(userOp.callData);
-    (address to, uint256 value, bytes memory data, uint256 txnGas, uint256 validUntil, uint8 operation) =
-      _decodeUserOpCallData(userOp.callData);
-
-    _execExtended(to, value, data, txnGas, nonce(), validUntil, operation, userOp.signature);
-    emit UserOpExecuted(userOpHash, nonce());
-  }
-
-  /// @notice Bundler convention: `userOp.callData = abi.encode(to, value,
-  ///         data, gas, validUntil, operation)`. This is a non-standard
-  ///         inner encoding — reference `IExecute.execute` callers can
-  ///         still drive this wallet by encoding
-  ///         `func = abi.encodeCall(executeUserOp, abi.encode(...))`.
-  function _decodeUserOpCallData(
-    bytes calldata callData
-  ) internal pure returns (address to, uint256 value, bytes memory data, uint256 gas, uint256 validUntil, uint8 operation) {
-    return abi.decode(callData, (address, uint256, bytes, uint256, uint256, uint8));
+  /// @dev Sends the EntryPoint the deposit it is missing to prefund the
+  ///      current op. A failed transfer is deliberately not reverted on:
+  ///      the EntryPoint re-checks the account's deposit right after and
+  ///      fails the op with its own, more descriptive error.
+  function _payPrefund(uint256 missingAccountFunds) internal virtual {
+    if (missingAccountFunds != 0) {
+      (bool success, ) = payable(msg.sender).call{ value: missingAccountFunds }('');
+      (success);
+    }
   }
 }

--- a/contracts/interfaces/IAccount.sol
+++ b/contracts/interfaces/IAccount.sol
@@ -1,22 +1,27 @@
 // SPDX-License-Identifier: MIT
 // Vendored from OpenZeppelin's draft-IERC4337.sol (April 2023 snapshot for v0.7).
-// `IAccount` is the marker interface every account must implement to be
-// usable through EntryPoint.handleOps. Only `validateUserOp` is required
-// to gate how the bundler is allowed to relay operations; `executeUserOp`
-// is a wallet-private helper that `MyMultiSigExtended` exposes for completeness.
+// `IAccount` is the interface every account must implement to be usable
+// through EntryPoint.handleOps: the EntryPoint calls `validateUserOp`
+// during the validation phase, then executes `userOp.callData` against
+// the account during the execution phase.
 pragma solidity ^0.8.0;
 
 import './PackedUserOperation.sol';
 
 interface IAccount {
-  /// @notice Validate the user operation. Must revert on failure.
+  /// @notice Validate the user operation. Must revert if the caller is not
+  ///         the trusted EntryPoint; signature failure is reported via the
+  ///         return value (1 = SIG_VALIDATION_FAILED), not a revert.
   /// @param userOp The parsed user-operation.
-  /// @param userOpHash The hash the bundler computed (EIP-712 over the union
-  ///                   of `(userOp.sender, nonce, ...)` and the EntryPoint domain).
-  /// @param missingAccountFunds The pre-deposit the EntryPoint would otherwise
-  ///                            refund to the account; we ignore it on purpose.
-  /// @return validationData Packed: aggregator flag in the high-1-byte, plus
-  ///                        `validAfter << 160 | validUntil` in the high-2-bytes.
+  /// @param userOpHash Hash of the op computed by the EntryPoint — binds the
+  ///                   op's fields, the EntryPoint address, and the chain id.
+  /// @param missingAccountFunds The deposit the account still owes the
+  ///                            EntryPoint to prefund this op's gas; the
+  ///                            account must transfer at least this much to
+  ///                            the EntryPoint before returning.
+  /// @return validationData 0 on success, 1 on signature failure; accounts
+  ///                        with time-bounded signatures pack
+  ///                        `validAfter (48) | validUntil (48) | authorizer (160)`.
   function validateUserOp(
     PackedUserOperation calldata userOp,
     bytes32 userOpHash,

--- a/contracts/test/MyMultiSigExtendedOps.t.sol
+++ b/contracts/test/MyMultiSigExtendedOps.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.24;
 import { Vm } from 'forge-std/Vm.sol';
 import { Helper } from './shared/helper.t.sol';
 import { MyMultiSigExtended } from '../MyMultiSigExtended.sol';
+import { PackedUserOperation } from '../interfaces/PackedUserOperation.sol';
 import './shared/mocks/MockEntryPoint.t.sol';
 
 /// @title MyMultiSigExtended Foundry tests
@@ -13,8 +14,10 @@ import './shared/mocks/MockEntryPoint.t.sol';
 ///            new execTransaction overloads.
 ///         3. The disabled legacy overloads revert with
 ///            `RequiresOperationByte()`.
-///         4. ERC-4337 `validateUserOp` rejects non-EntryPoint
-///            callers and approves honest ones.
+///         4. ERC-4337 v0.7: `validateUserOp` / `execute` are
+///            EntryPoint-gated, owners sign the EntryPoint's
+///            `userOpHash`, the prefund is paid, and the EntryPoint's
+///            2D nonces work independently of the wallet's own nonce.
 contract MyMultiSigExtendedTest is Helper {
   MyMultiSigExtended internal wallet;
   MockEntryPoint internal mockEntryPoint;
@@ -184,5 +187,155 @@ contract MyMultiSigExtendedTest is Helper {
       txnGas + 1_000,
       'DELEGATECALL should be bounded by txnGas, not gasleft()'
     );
+  }
+
+  // ---------- ERC-4337 v0.7 ----------
+
+  /// @dev Builds an op whose `callData` is the standard
+  ///      `execute(address,uint256,bytes)` call the EntryPoint relays to
+  ///      the account verbatim.
+  function _buildUserOp(
+    address to,
+    uint256 value,
+    bytes memory data,
+    uint256 opNonce
+  ) internal view returns (PackedUserOperation memory op) {
+    op = PackedUserOperation({
+      sender: address(wallet),
+      nonce: opNonce,
+      initCode: '',
+      callData: abi.encodeWithSignature('execute(address,uint256,bytes)', to, value, data),
+      accountGasLimits: bytes32(0),
+      preVerificationGas: 0,
+      gasFees: bytes32(0),
+      paymasterAndData: '',
+      signature: ''
+    });
+  }
+
+  /// @dev Owners vote on the EIP-191 wrap of the EntryPoint's
+  ///      `userOpHash` — raw `vm.sign` over the wallet's
+  ///      `userOpSigningHash`, no EIP-712 wallet-domain framing.
+  function _signUserOp(PackedUserOperation memory op, uint256 signerCount) internal view returns (bytes memory) {
+    bytes32 digest = wallet.userOpSigningHash(mockEntryPoint.getUserOpHash(op));
+    Vote[] memory votes = new Vote[](signerCount);
+    for (uint256 i = 0; i < signerCount; i++) {
+      (uint8 v, bytes32 r, bytes32 s) = vm.sign(OWNERS_PK[i], digest);
+      votes[i] = Vote({ owner: OWNERS[i], sig: abi.encodePacked(r, s, v) });
+    }
+    return abi.encode(votes);
+  }
+
+  function _handleOp(PackedUserOperation memory op) internal {
+    PackedUserOperation[] memory ops = new PackedUserOperation[](1);
+    ops[0] = op;
+    mockEntryPoint.handleOps(ops, payable(address(0xbeef)));
+  }
+
+  function test_userOp_executes_and_ignores_wallet_nonce() public {
+    vm.deal(address(wallet), 2 ether);
+    address recipient = address(0xa11ce);
+    uint96 walletNonceBefore = wallet.nonce();
+
+    PackedUserOperation memory op = _buildUserOp(recipient, 1 ether, '', mockEntryPoint.getNonce(address(wallet), 0));
+    op.signature = _signUserOp(op, 2);
+    _handleOp(op);
+
+    assertEq(recipient.balance, 1 ether, 'userOp should have transferred the ETH');
+    assertEq(wallet.nonce(), walletNonceBefore, 'wallet EIP-712 nonce must not move on the 4337 path');
+    assertEq(mockEntryPoint.getNonce(address(wallet), 0), 1, 'EntryPoint sequence should advance');
+    // The relayed callData is a plain `execute` call — the standard
+    // `account.call(userOp.callData)` flow, no custom tuple encoding.
+    assertEq(bytes4(mockEntryPoint.lastCallData()), wallet.execute.selector);
+  }
+
+  function test_userOp_2d_nonce_keys_are_independent() public {
+    vm.deal(address(wallet), 2 ether);
+    address recipient = address(0xa11ce);
+
+    // Two ops on distinct keys, no dependency on each other or on the
+    // wallet's internal nonce.
+    PackedUserOperation memory opKey0 = _buildUserOp(recipient, 0.5 ether, '', mockEntryPoint.getNonce(address(wallet), 0));
+    opKey0.signature = _signUserOp(opKey0, 2);
+    PackedUserOperation memory opKey5 = _buildUserOp(recipient, 0.5 ether, '', mockEntryPoint.getNonce(address(wallet), 5));
+    opKey5.signature = _signUserOp(opKey5, 2);
+
+    _handleOp(opKey5);
+    _handleOp(opKey0);
+    assertEq(recipient.balance, 1 ether);
+
+    // Replaying a consumed EntryPoint nonce fails in the EntryPoint.
+    vm.expectRevert(
+      abi.encodeWithSelector(MockEntryPoint.InvalidAccountNonce.selector, address(wallet), opKey0.nonce)
+    );
+    _handleOp(opKey0);
+  }
+
+  function test_userOp_pays_prefund() public {
+    vm.deal(address(wallet), 2 ether);
+    mockEntryPoint.setRequiredPrefund(0.25 ether);
+    address recipient = address(0xa11ce);
+
+    PackedUserOperation memory op = _buildUserOp(recipient, 1 ether, '', mockEntryPoint.getNonce(address(wallet), 0));
+    op.signature = _signUserOp(op, 2);
+    _handleOp(op);
+
+    assertEq(recipient.balance, 1 ether);
+    assertEq(
+      mockEntryPoint.balanceOf(address(wallet)),
+      0.25 ether,
+      'validateUserOp should have topped up the EntryPoint deposit'
+    );
+  }
+
+  function test_userOp_below_threshold_returns_sig_validation_failed() public {
+    vm.deal(address(wallet), 2 ether);
+    PackedUserOperation memory op = _buildUserOp(address(0xa11ce), 1 ether, '', mockEntryPoint.getNonce(address(wallet), 0));
+    // Only 1 of 2 required owner votes.
+    op.signature = _signUserOp(op, 1);
+    vm.expectRevert(
+      abi.encodeWithSelector(MockEntryPoint.SignatureValidationFailed.selector, address(wallet), uint256(1))
+    );
+    _handleOp(op);
+  }
+
+  function test_userOp_approveHash_votes_count() public {
+    vm.deal(address(wallet), 2 ether);
+    address recipient = address(0xa11ce);
+    PackedUserOperation memory op = _buildUserOp(recipient, 1 ether, '', mockEntryPoint.getNonce(address(wallet), 0));
+
+    // Both owners pre-approve the userOp digest on-chain; the op then
+    // needs no signature blob at all.
+    bytes32 digest = wallet.userOpSigningHash(mockEntryPoint.getUserOpHash(op));
+    vm.prank(OWNERS[0]);
+    wallet.approveHash(digest);
+    vm.prank(OWNERS[1]);
+    wallet.approveHash(digest);
+
+    _handleOp(op);
+    assertEq(recipient.balance, 1 ether);
+  }
+
+  function test_userOp_execute_respects_allowlist() public {
+    vm.deal(address(wallet), 2 ether);
+    // Enable the allowlist for some other target; the op's target is not on it.
+    vm.prank(address(wallet));
+    wallet.setAllowedTarget(address(0xd00d), true);
+
+    PackedUserOperation memory op = _buildUserOp(address(0xa11ce), 1 ether, '', mockEntryPoint.getNonce(address(wallet), 0));
+    op.signature = _signUserOp(op, 2);
+    vm.expectRevert(abi.encodeWithSignature('TargetNotAllowed(address)', address(0xa11ce)));
+    _handleOp(op);
+  }
+
+  function test_validateUserOp_rejects_non_entrypoint() public {
+    PackedUserOperation memory op = _buildUserOp(address(0xa11ce), 0, '', 0);
+    vm.expectRevert(abi.encodeWithSignature('NotEntryPoint()'));
+    wallet.validateUserOp(op, bytes32(0), 0);
+  }
+
+  function test_execute_rejects_non_entrypoint() public {
+    vm.expectRevert(abi.encodeWithSignature('NotEntryPoint()'));
+    wallet.execute(address(0xa11ce), 0, '');
   }
 }

--- a/contracts/test/shared/mocks/MockEntryPoint.t.sol
+++ b/contracts/test/shared/mocks/MockEntryPoint.t.sol
@@ -2,65 +2,114 @@
 pragma solidity ^0.8.0;
 
 import { IEntryPoint } from '../../../interfaces/IEntryPoint.sol';
+import { IAccount } from '../../../interfaces/IAccount.sol';
 import { PackedUserOperation } from '../../../interfaces/PackedUserOperation.sol';
 
 /// @title MockEntryPoint
-/// @notice Minimal EntryPoint stub for Foundry tests of
-///         `MyMultiSigExtended` v0.5.0 `validateUserOp` /
-///         `executeUserOp`. Tracks deposits, dispatches a single
-///         UserOp via `handleOps`, and lets Foundry assertions reach
-///         into the call data without decoding.
+/// @notice Minimal EntryPoint v0.7 stub for Foundry tests of
+///         `MyMultiSigExtended`'s ERC-4337 surface. Mirrors the canonical
+///         EntryPoint semantics the wallet relies on:
+///         - `getUserOpHash` binds the op's fields, this EntryPoint's
+///           address, and the chain id (same encoding as the reference
+///           `UserOperationLib`).
+///         - 2D nonces: `userOp.nonce` is `key (192 bits) | seq (64 bits)`;
+///           the sequence is validated and consumed per `(sender, key)`.
+///         - Validation phase: calls `validateUserOp` with the deposit the
+///           account is missing, credits ETH the account sends back, and
+///           rejects the op unless the prefund is covered and
+///           `validationData == 0`.
+///         - Execution phase: relays `userOp.callData` to the account
+///           verbatim via `sender.call(callData)`. Unlike the real
+///           EntryPoint (which logs a failed op and moves on), an inner
+///           revert is bubbled so tests can assert on the wallet's errors.
 contract MockEntryPoint is IEntryPoint {
   mapping(address => uint256) private _deposits;
+  mapping(address => mapping(uint192 => uint64)) private _nonceSequence;
 
-  // Echoes the last user-op the test suite called `handleOps(...)`
-  // with. Lets Foundry assertions reach into the call data without
-  // decoding.
+  /// @notice Prefund (in wei) each op must have on deposit before
+  ///         execution. Tests set this to exercise the account's
+  ///         `missingAccountFunds` payment path; the default of 0 mirrors
+  ///         a fully-sponsored op.
+  uint256 public requiredPrefund;
+
+  // Echoes the last user-op callData relayed to an account, so Foundry
+  // assertions can reach into it without decoding.
   bytes public lastCallData;
 
-  event UserOpHandled(address indexed sender, bytes callData);
+  event UserOpHandled(address indexed sender, bytes32 indexed userOpHash, bytes callData);
 
-  function handleOps(
-    PackedUserOperation[] calldata ops,
-    address payable /* beneficiary */
-  ) external override {
-    require(ops.length == 1, 'MockEntryPoint: exactly one op');
-    lastCallData = ops[0].callData;
-    // Forward to the wallet's executeUserOp so the wallet-side flow
-    // runs end-to-end during a test.
-    (bool success, bytes memory ret) = ops[0].sender.call(
-      abi.encodeWithSelector(this.forwardExecuteUserOp.selector, ops[0])
-    );
-    if (!success) {
-      assembly {
-        revert(add(ret, 0x20), mload(ret))
-      }
-    }
-    emit UserOpHandled(ops[0].sender, ops[0].callData);
+  error InvalidAccountNonce(address sender, uint256 nonce);
+  error PrefundNotPaid(address sender, uint256 deposit, uint256 required);
+  error SignatureValidationFailed(address sender, uint256 validationData);
+
+  function setRequiredPrefund(uint256 requiredPrefund_) external {
+    requiredPrefund = requiredPrefund_;
   }
 
-  function forwardExecuteUserOp(PackedUserOperation calldata op) external {
-    require(msg.sender == address(this), 'MockEntryPoint: only self');
-    (bool success, bytes memory ret) = op.sender.call(
-      abi.encodeWithSignature('executeUserOp((address,uint256,bytes,bytes32,uint256,bytes32,bytes,bytes,bytes))', op)
+  /// @notice Same hash the canonical v0.7 EntryPoint computes: the packed
+  ///         op fields, wrapped with this EntryPoint's address and chain id.
+  function getUserOpHash(PackedUserOperation calldata userOp) public view returns (bytes32) {
+    bytes32 packed = keccak256(
+      abi.encode(
+        userOp.sender,
+        userOp.nonce,
+        keccak256(userOp.initCode),
+        keccak256(userOp.callData),
+        userOp.accountGasLimits,
+        userOp.preVerificationGas,
+        userOp.gasFees,
+        keccak256(userOp.paymasterAndData)
+      )
     );
+    return keccak256(abi.encode(packed, address(this), block.chainid));
+  }
+
+  /// @notice Next valid `userOp.nonce` for `(sender, key)` — `key` in the
+  ///         high 192 bits, the per-key sequence in the low 64 bits.
+  function getNonce(address sender, uint192 key) public view returns (uint256) {
+    return (uint256(key) << 64) | _nonceSequence[sender][key];
+  }
+
+  function handleOps(PackedUserOperation[] calldata ops, address payable /* beneficiary */) external override {
+    for (uint256 i = 0; i < ops.length; ++i) {
+      _handleOp(ops[i]);
+    }
+  }
+
+  function _handleOp(PackedUserOperation calldata op) internal {
+    // 2D nonce: validate and consume the sequence for the op's key.
+    uint192 key = uint192(op.nonce >> 64);
+    uint64 seq = uint64(op.nonce);
+    if (_nonceSequence[op.sender][key] != seq) revert InvalidAccountNonce(op.sender, op.nonce);
+    _nonceSequence[op.sender][key] = seq + 1;
+
+    // Validation phase: ask the account to validate and top up its deposit.
+    bytes32 userOpHash = getUserOpHash(op);
+    uint256 deposit = _deposits[op.sender];
+    uint256 missing = deposit >= requiredPrefund ? 0 : requiredPrefund - deposit;
+    uint256 validationData = IAccount(op.sender).validateUserOp(op, userOpHash, missing);
+    if (_deposits[op.sender] < requiredPrefund)
+      revert PrefundNotPaid(op.sender, _deposits[op.sender], requiredPrefund);
+    if (validationData != 0) revert SignatureValidationFailed(op.sender, validationData);
+
+    // Execution phase: relay the op's callData to the account verbatim.
+    lastCallData = op.callData;
+    (bool success, bytes memory ret) = op.sender.call(op.callData);
     if (!success) {
       assembly {
         revert(add(ret, 0x20), mload(ret))
       }
     }
+    emit UserOpHandled(op.sender, userOpHash, op.callData);
   }
 
   function depositTo(address account) external payable override {
     _deposits[account] += msg.value;
   }
 
-  function withdrawTo(
-    address payable withdrawAddress,
-    uint256 withdrawAmount
-  ) external override {
+  function withdrawTo(address payable withdrawAddress, uint256 withdrawAmount) external override {
     _deposits[msg.sender] -= withdrawAmount;
-    (bool ok, ) = withdrawAddress.call{value: withdrawAmount}('');
+    (bool ok, ) = withdrawAddress.call{ value: withdrawAmount }('');
     require(ok, 'MockEntryPoint: withdraw failed');
   }
 
@@ -68,5 +117,10 @@ contract MockEntryPoint is IEntryPoint {
     return _deposits[account];
   }
 
-  receive() external payable {}
+  /// @notice Plain ETH sent to the EntryPoint (the account's
+  ///         `missingAccountFunds` payment during validation) is credited
+  ///         to the sender's deposit, matching the real EntryPoint.
+  receive() external payable {
+    _deposits[msg.sender] += msg.value;
+  }
 }

--- a/types/MyMultiSigExtended.ts
+++ b/types/MyMultiSigExtended.ts
@@ -100,8 +100,8 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     "execTransaction(address,uint256,bytes,uint256,uint256,uint256,bytes)": FunctionFragment;
     "execTransactionFromModule(address,uint256,bytes,uint256)": FunctionFragment;
     "execTransactionWithSpendingAllowance(address,uint256,bytes,uint256,uint256,bytes)": FunctionFragment;
+    "execute(address,uint256,bytes)": FunctionFragment;
     "executeScheduled(address,uint256,bytes,uint256,uint256,uint256,bytes)": FunctionFragment;
-    "executeUserOp((address,uint256,bytes,bytes,bytes32,uint256,bytes32,bytes,bytes))": FunctionFragment;
     "generateHash(address,uint256,bytes,uint256,uint256,uint256)": FunctionFragment;
     "generateHashOp(address,uint256,bytes,uint256,uint256,uint256,uint8)": FunctionFragment;
     "getApprovedOwners(bytes32)": FunctionFragment;
@@ -154,6 +154,7 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     "threshold()": FunctionFragment;
     "timelockDelay()": FunctionFragment;
     "unsignMessage(bytes)": FunctionFragment;
+    "userOpSigningHash(bytes32)": FunctionFragment;
     "validateUserOp((address,uint256,bytes,bytes,bytes32,uint256,bytes32,bytes,bytes),bytes32,uint256)": FunctionFragment;
     "version()": FunctionFragment;
   };
@@ -182,8 +183,8 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
       | "execTransaction(address,uint256,bytes,uint256,uint256,uint256,bytes)"
       | "execTransactionFromModule"
       | "execTransactionWithSpendingAllowance"
+      | "execute"
       | "executeScheduled"
-      | "executeUserOp"
       | "generateHash"
       | "generateHashOp"
       | "getApprovedOwners"
@@ -236,6 +237,7 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
       | "threshold"
       | "timelockDelay"
       | "unsignMessage"
+      | "userOpSigningHash"
       | "validateUserOp"
       | "version"
   ): FunctionFragment;
@@ -393,6 +395,14 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     ]
   ): string;
   encodeFunctionData(
+    functionFragment: "execute",
+    values: [
+      PromiseOrValue<string>,
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<BytesLike>
+    ]
+  ): string;
+  encodeFunctionData(
     functionFragment: "executeScheduled",
     values: [
       PromiseOrValue<string>,
@@ -403,10 +413,6 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
       PromiseOrValue<BigNumberish>,
       PromiseOrValue<BytesLike>
     ]
-  ): string;
-  encodeFunctionData(
-    functionFragment: "executeUserOp",
-    values: [PackedUserOperationStruct]
   ): string;
   encodeFunctionData(
     functionFragment: "generateHash",
@@ -676,6 +682,10 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     values: [PromiseOrValue<BytesLike>]
   ): string;
   encodeFunctionData(
+    functionFragment: "userOpSigningHash",
+    values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
     functionFragment: "validateUserOp",
     values: [
       PackedUserOperationStruct,
@@ -770,12 +780,9 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     functionFragment: "execTransactionWithSpendingAllowance",
     data: BytesLike
   ): Result;
+  decodeFunctionResult(functionFragment: "execute", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "executeScheduled",
-    data: BytesLike
-  ): Result;
-  decodeFunctionResult(
-    functionFragment: "executeUserOp",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -957,6 +964,10 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
+    functionFragment: "userOpSigningHash",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "validateUserOp",
     data: BytesLike
   ): Result;
@@ -991,7 +1002,6 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     "TransactionScheduled(bytes32,uint256,address)": EventFragment;
     "TxFailure(address,address,uint256,bytes,uint256,uint256,bytes)": EventFragment;
     "TxFailureOp(address,address,uint256,bytes,uint256,uint256,uint8,bytes)": EventFragment;
-    "UserOpExecuted(bytes32,uint256)": EventFragment;
   };
 
   getEvent(nameOrSignatureOrTopic: "AllowedTargetSet"): EventFragment;
@@ -1026,7 +1036,6 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
   getEvent(nameOrSignatureOrTopic: "TransactionScheduled"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "TxFailure"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "TxFailureOp"): EventFragment;
-  getEvent(nameOrSignatureOrTopic: "UserOpExecuted"): EventFragment;
 }
 
 export interface AllowedTargetSetEventObject {
@@ -1348,17 +1357,6 @@ export type TxFailureOpEvent = TypedEvent<
 
 export type TxFailureOpEventFilter = TypedEventFilter<TxFailureOpEvent>;
 
-export interface UserOpExecutedEventObject {
-  userOpHash: string;
-  nonce: BigNumber;
-}
-export type UserOpExecutedEvent = TypedEvent<
-  [string, BigNumber],
-  UserOpExecutedEventObject
->;
-
-export type UserOpExecutedEventFilter = TypedEventFilter<UserOpExecutedEvent>;
-
 export interface MyMultiSigExtended extends BaseContract {
   connect(signerOrProvider: Signer | Provider | string): this;
   attach(addressOrName: string): this;
@@ -1541,6 +1539,13 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
+    execute(
+      to: PromiseOrValue<string>,
+      value: PromiseOrValue<BigNumberish>,
+      data: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
     executeScheduled(
       to: PromiseOrValue<string>,
       value: PromiseOrValue<BigNumberish>,
@@ -1549,11 +1554,6 @@ export interface MyMultiSigExtended extends BaseContract {
       txnNonce: PromiseOrValue<BigNumberish>,
       validUntil: PromiseOrValue<BigNumberish>,
       signatures: PromiseOrValue<BytesLike>,
-      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
-    ): Promise<ContractTransaction>;
-
-    executeUserOp(
-      userOp: PackedUserOperationStruct,
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
@@ -1844,12 +1844,17 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
+    userOpSigningHash(
+      userOpHash: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[string]>;
+
     validateUserOp(
       userOp: PackedUserOperationStruct,
-      arg1: PromiseOrValue<BytesLike>,
-      arg2: PromiseOrValue<BigNumberish>,
-      overrides?: CallOverrides
-    ): Promise<[BigNumber] & { validationData: BigNumber }>;
+      userOpHash: PromiseOrValue<BytesLike>,
+      missingAccountFunds: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
 
     version(overrides?: CallOverrides): Promise<[string]>;
   };
@@ -2007,6 +2012,13 @@ export interface MyMultiSigExtended extends BaseContract {
     overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  execute(
+    to: PromiseOrValue<string>,
+    value: PromiseOrValue<BigNumberish>,
+    data: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
   executeScheduled(
     to: PromiseOrValue<string>,
     value: PromiseOrValue<BigNumberish>,
@@ -2015,11 +2027,6 @@ export interface MyMultiSigExtended extends BaseContract {
     txnNonce: PromiseOrValue<BigNumberish>,
     validUntil: PromiseOrValue<BigNumberish>,
     signatures: PromiseOrValue<BytesLike>,
-    overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
-  ): Promise<ContractTransaction>;
-
-  executeUserOp(
-    userOp: PackedUserOperationStruct,
     overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
@@ -2308,12 +2315,17 @@ export interface MyMultiSigExtended extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  userOpSigningHash(
+    userOpHash: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   validateUserOp(
     userOp: PackedUserOperationStruct,
-    arg1: PromiseOrValue<BytesLike>,
-    arg2: PromiseOrValue<BigNumberish>,
-    overrides?: CallOverrides
-  ): Promise<BigNumber>;
+    userOpHash: PromiseOrValue<BytesLike>,
+    missingAccountFunds: PromiseOrValue<BigNumberish>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
 
   version(overrides?: CallOverrides): Promise<string>;
 
@@ -2469,6 +2481,13 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: CallOverrides
     ): Promise<boolean>;
 
+    execute(
+      to: PromiseOrValue<string>,
+      value: PromiseOrValue<BigNumberish>,
+      data: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
     executeScheduled(
       to: PromiseOrValue<string>,
       value: PromiseOrValue<BigNumberish>,
@@ -2479,11 +2498,6 @@ export interface MyMultiSigExtended extends BaseContract {
       signatures: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<boolean>;
-
-    executeUserOp(
-      userOp: PackedUserOperationStruct,
-      overrides?: CallOverrides
-    ): Promise<void>;
 
     generateHash(
       to: PromiseOrValue<string>,
@@ -2770,10 +2784,15 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: CallOverrides
     ): Promise<void>;
 
+    userOpSigningHash(
+      userOpHash: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
     validateUserOp(
       userOp: PackedUserOperationStruct,
-      arg1: PromiseOrValue<BytesLike>,
-      arg2: PromiseOrValue<BigNumberish>,
+      userOpHash: PromiseOrValue<BytesLike>,
+      missingAccountFunds: PromiseOrValue<BigNumberish>,
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
@@ -3042,15 +3061,6 @@ export interface MyMultiSigExtended extends BaseContract {
       operation?: null,
       reason?: null
     ): TxFailureOpEventFilter;
-
-    "UserOpExecuted(bytes32,uint256)"(
-      userOpHash?: PromiseOrValue<BytesLike> | null,
-      nonce?: PromiseOrValue<BigNumberish> | null
-    ): UserOpExecutedEventFilter;
-    UserOpExecuted(
-      userOpHash?: PromiseOrValue<BytesLike> | null,
-      nonce?: PromiseOrValue<BigNumberish> | null
-    ): UserOpExecutedEventFilter;
   };
 
   estimateGas: {
@@ -3195,6 +3205,13 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
+    execute(
+      to: PromiseOrValue<string>,
+      value: PromiseOrValue<BigNumberish>,
+      data: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
     executeScheduled(
       to: PromiseOrValue<string>,
       value: PromiseOrValue<BigNumberish>,
@@ -3203,11 +3220,6 @@ export interface MyMultiSigExtended extends BaseContract {
       txnNonce: PromiseOrValue<BigNumberish>,
       validUntil: PromiseOrValue<BigNumberish>,
       signatures: PromiseOrValue<BytesLike>,
-      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
-    ): Promise<BigNumber>;
-
-    executeUserOp(
-      userOp: PackedUserOperationStruct,
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
@@ -3496,11 +3508,16 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
+    userOpSigningHash(
+      userOpHash: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     validateUserOp(
       userOp: PackedUserOperationStruct,
-      arg1: PromiseOrValue<BytesLike>,
-      arg2: PromiseOrValue<BigNumberish>,
-      overrides?: CallOverrides
+      userOpHash: PromiseOrValue<BytesLike>,
+      missingAccountFunds: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
     version(overrides?: CallOverrides): Promise<BigNumber>;
@@ -3654,6 +3671,13 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
+    execute(
+      to: PromiseOrValue<string>,
+      value: PromiseOrValue<BigNumberish>,
+      data: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
     executeScheduled(
       to: PromiseOrValue<string>,
       value: PromiseOrValue<BigNumberish>,
@@ -3662,11 +3686,6 @@ export interface MyMultiSigExtended extends BaseContract {
       txnNonce: PromiseOrValue<BigNumberish>,
       validUntil: PromiseOrValue<BigNumberish>,
       signatures: PromiseOrValue<BytesLike>,
-      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
-    ): Promise<PopulatedTransaction>;
-
-    executeUserOp(
-      userOp: PackedUserOperationStruct,
       overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
@@ -3957,11 +3976,16 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
+    userOpSigningHash(
+      userOpHash: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
     validateUserOp(
       userOp: PackedUserOperationStruct,
-      arg1: PromiseOrValue<BytesLike>,
-      arg2: PromiseOrValue<BigNumberish>,
-      overrides?: CallOverrides
+      userOpHash: PromiseOrValue<BytesLike>,
+      missingAccountFunds: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
     version(overrides?: CallOverrides): Promise<PopulatedTransaction>;


### PR DESCRIPTION
## Problem

The v0.5.0 ERC-4337 surface was incomplete and non-portable — it could not run through the canonical EntryPoint (`0x0000000071727De22E5E9d8BDe0dFeC0CEB6a7d7`) or any standard bundler:

1. **`userOp.callData` was decoded as a raw selector-less tuple.** The EntryPoint's execution phase does `account.call(userOp.callData)`, which needs a function selector; the custom `abi.encode(to, value, data, gas, validUntil, operation)` encoding only worked with a bespoke bundler.
2. **Validation signed the wallet's own EIP-712 transaction hash, not `userOpHash`.** The signatures therefore did not bind the op's gas fields, the EntryPoint address, or the EntryPoint nonce.
3. **`missingAccountFunds` was ignored and `validateUserOp` was `view`**, so the account could never top up its EntryPoint deposit and any non-sponsored op failed with `AA21`.
4. **`userOp.nonce` was forced equal to the wallet's internal `_txnNonce`**, fighting the EntryPoint's 2D nonce scheme (key ‖ sequence) and breaking parallel ops.

## Fix

- `validateUserOp` is now non-`view`, EntryPoint-gated, validates a threshold of owner votes over the EIP-191 wrap of the EntryPoint's `userOpHash` (exposed as `userOpSigningHash`, so owners can vote via `personal_sign` or on-chain `approveHash`), returns `SIG_VALIDATION_FAILED` (1) instead of reverting on a bad signature, and transfers `missingAccountFunds` to the EntryPoint.
- Execution goes through a new standard `execute(address to, uint256 value, bytes data)`, callable only by the EntryPoint — `userOp.callData` encodes it directly, so the stock `account.call(callData)` relay works. It still runs the wallet's pre-exec gates (timelock reverse-route, guard, allowlist) and the post-exec guard hook, so the 4337 path cannot bypass wallet policy.
- The wallet's `_txnNonce` is neither read nor bumped on the 4337 path; replay protection is the EntryPoint's 2D nonce, which is already bound into `userOpHash`.
- Removed the non-standard `executeUserOp(PackedUserOperation)`, the tuple decoder, the `UserOpExecuted` event, and the now-unused `InvalidNonce` error; regenerated the committed types.

## Tests

`MockEntryPoint` now mirrors the canonical v0.7 semantics (real `getUserOpHash` encoding, 2D nonces, prefund accounting, verbatim `callData` relay). New Foundry tests drive `handleOps` end-to-end: transfer via `execute`, wallet nonce untouched, independent nonce keys + replay rejection, prefund payment, below-threshold sigs → `SIG_VALIDATION_FAILED`, `approveHash` voting, allowlist enforcement, and EntryPoint-only gating.

- `forge test`: 148 passing
- `npx hardhat test`: 301 passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)