### PR TITLE
feat(factory): implement the CREATE2 deterministic wallets claimed in v0.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,13 +189,23 @@ Constructor signature: `new MyMultiSigExtended(name, owners, threshold, isOnlyOw
 
 Paymaster support drops out naturally: a paymaster can pre-fund via `EntryPoint.depositTo(address(this))`; bundlers assemble UserOps with `paymasterAndData != 0` and the wallet's `validateUserOp` is permissive on value-funded flows.
 
-### 3. 🌐 CREATE2 deterministic wallets (deferred to a follow-up)
+### 3. 🌐 CREATE2 deterministic wallets
 
-The original v0.5.0 plan called for a CREATE2-based factory path (`Clones.cloneDeterministic` against a dedicated implementation). That work would require converting `MyMultiSigExtended` into `Initializable` (a non-trivial storage layout shift on a non-upgradeable wallet), so it was **deferred to a follow-up release** to keep this PR focused. The v0.5.0 factory stores the same deployer trio as v0.4.0 (`MyMultiSigDeployer`, `MyMultiSigExtendedDeployer`, `MyMultiSigAdvancedDeployer`).
+The factory exposes a deterministic (CREATE2) creation path next to each classic one. Wallets deploy via salted creation (`new MyMultiSig{salt: ...}(...)` inside the deployers) — full creation bytecode, ordinary constructors, no proxies and no `Initializable` — so the deployed wallets are byte-identical to the classic-path ones.
 
-When CREATE2 ships, the plan is:
-- Make `MyMultiSigExtended` `Initializable`; `MyMultiSigExtendedDeployer` calls `new MyMultiSigExtendedProxy()` followed by `initialize(name, owners, threshold, isOnlyOwnerRequest, entryPoint)`.
-- The factory holds an immutable `myMultiSigExtendedImpl` (the wallet implementation used as a `Clones.cloneDeterministic` target) and uses `OZ Clones.cloneDeterministic(salt, myMultiSigExtendedImpl)` to deploy.
+| Classic (CREATE) | Deterministic (CREATE2) | Predict without deploying |
+| --- | --- | --- |
+| `createMultiSig(name, owners, threshold)` | `createDeterministicMultiSig(..., salt)` | `predictMultiSigAddress(creator, ..., salt)` |
+| `createMyMultiSigExtended(...)` | `createDeterministicMyMultiSigExtended(..., salt)` | `predictMyMultiSigExtendedAddress(creator, ..., salt)` |
+| `createMyMultiSigAdvanced(...)` | `createDeterministicMyMultiSigAdvanced(..., salt)` | `predictMyMultiSigAdvancedAddress(creator, ..., salt)` |
+
+Address derivation:
+
+- The factory forwards `computeSalt(msg.sender, salt) = keccak256(abi.encode(creator, salt))` to the deployer, so two creators using the same salt never race for one address.
+- Each deployer additionally namespaces the salt by its **direct caller** (`keccak256(abi.encode(msg.sender, salt))`) before the CREATE2. A third party calling a deployer directly therefore lands in its own address space and can never squat an address that a factory-mediated deploy resolves to. It also keeps Advanced deploys (routed through `MyMultiSigAdvancedDeployer` → `MyMultiSigExtendedDeployer`) collision-free against Extended deploys that share a salt and constructor arguments.
+- The final wallet address is a pure function of `(deployer address, creator, salt, constructor arguments)`. Deploy the factory + deployer set at the same addresses on several chains (see `FACTORY_SALT` / `CANONICAL_CREATE2_DEPLOYER` in `constants/extended.ts`) and the same creator + salt + arguments yield the **same wallet address on every chain**.
+
+Re-using a salt with identical arguments reverts (the CREATE2 target address is occupied). ERC-4337 note: `validateUserOp` requires the wallet to be already deployed (`userOp.sender == address(this)`); the deterministic path gives counterfactual **addresses**, not initCode-based counterfactual deployment.
 
 ### Migration story
 

--- a/constants/extended.ts
+++ b/constants/extended.ts
@@ -2,18 +2,22 @@
 // `constants/index.ts` (the npm-published artifact) keeps a stable shape
 // for downstream consumers.
 //
-// `FACTORY_SALT` and `CHAIN_AGNOSTIC_KEY_DEFAULT` are reserved for the
-// upcoming CREATE2 path (deferred to a follow-up because it requires
-// making `MyMultiSigExtended` `Initializable`).
+// `FACTORY_SALT` and `CANONICAL_CREATE2_DEPLOYER` support the CREATE2
+// deployment story: wallet addresses are deterministic given the deployer
+// addresses, so deploying the factory + deployer set at the same addresses
+// on every chain (factory proxy deployed with `FACTORY_SALT` through the
+// canonical CREATE2 deployer) makes `createDeterministicMultiSig` /
+// `createDeterministicMyMultiSigExtended` / `createDeterministicMyMultiSigAdvanced`
+// yield the same wallet address on every chain for the same creator, salt
+// and constructor arguments.
 //
 // `ENTRY_POINT_V07_ADDRESS` is the canonical EntryPoint v0.7 address,
 // which is identical on every chain. Active as of v0.5.0.
 import { hexlify, zeroPad } from 'ethers/lib/utils'
 
-// 32-byte salt reserved for the v0.5.0+ factory proxy deploy (CREATE2
-// follow-up). The salt itself becomes part of the address on every
-// chain, so changing it requires re-deploying the factory proxy across
-// all chains.
+// 32-byte salt for the v0.5.0+ factory proxy deploy. The salt itself
+// becomes part of the address on every chain, so changing it requires
+// re-deploying the factory proxy across all chains.
 const SALT_SEED = Buffer.from(hexlify(Buffer.from('mymultisig.app/v0.5.0')).slice(2).slice(0, 60), 'hex')
 
 export default {

--- a/contracts/MyMultiSigAdvancedDeployer.sol
+++ b/contracts/MyMultiSigAdvancedDeployer.sol
@@ -15,6 +15,12 @@ import './interfaces/IMyMultiSigExtendedDeployer.sol';
 ///         distinction lives purely in factory bookkeeping. An Advanced-only
 ///         release can later replace this contract with one that embeds
 ///         different bytecode without touching the factory's call surface.
+///
+///         The CREATE2 path routes through the extended deployer too. Since
+///         the extended deployer namespaces salts by its direct caller, the
+///         wallets deployed here live in this contract's namespace —
+///         an Advanced deploy can never collide with an Extended deploy that
+///         used the same salt and constructor arguments.
 contract MyMultiSigAdvancedDeployer is IMyMultiSigAdvancedDeployer {
   /// @custom:oz-upgrades-unsafe-allow state-variable-immutable
   address public immutable extendedDeployer;
@@ -38,5 +44,59 @@ contract MyMultiSigAdvancedDeployer is IMyMultiSigAdvancedDeployer {
       isOnlyOwnerRequest_,
       entryPoint_
     );
+  }
+
+  /// @notice Deploys an Advanced wallet via CREATE2 (routed through the
+  ///         extended deployer, in this contract's salt namespace).
+  /// @dev    Reverts if a contract already exists at the target address
+  ///         (same caller, salt and constructor arguments).
+  /// @param salt_ Caller-chosen salt.
+  /// @return contractAddress The deployed wallet address.
+  function deployMyMultiSigAdvancedDeterministic(
+    bytes32 salt_,
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_,
+    bool isOnlyOwnerRequest_,
+    address entryPoint_
+  ) external override returns (address contractAddress) {
+    contractAddress = IMyMultiSigExtendedDeployer(extendedDeployer).deployMyMultiSigExtendedDeterministic(
+      _callerSalt(salt_),
+      contractName_,
+      owners_,
+      threshold_,
+      isOnlyOwnerRequest_,
+      entryPoint_
+    );
+  }
+
+  /// @notice Predicts the address `deployMyMultiSigAdvancedDeterministic`
+  ///         would deploy to for the same caller, salt and constructor
+  ///         arguments.
+  /// @dev    Must be called by the same account that will perform the deploy
+  ///         (the salt is namespaced by `msg.sender`).
+  function predictMyMultiSigAdvancedAddress(
+    bytes32 salt_,
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_,
+    bool isOnlyOwnerRequest_,
+    address entryPoint_
+  ) external view override returns (address contractAddress) {
+    contractAddress = IMyMultiSigExtendedDeployer(extendedDeployer).predictMyMultiSigExtendedAddress(
+      _callerSalt(salt_),
+      contractName_,
+      owners_,
+      threshold_,
+      isOnlyOwnerRequest_,
+      entryPoint_
+    );
+  }
+
+  /// @dev Namespaces a caller-chosen salt by `msg.sender`, mirroring the
+  ///      extended deployer's own namespacing so direct callers of this
+  ///      contract each get their own address space too.
+  function _callerSalt(bytes32 salt_) private view returns (bytes32) {
+    return keccak256(abi.encode(msg.sender, salt_));
   }
 }

--- a/contracts/MyMultiSigDeployer.sol
+++ b/contracts/MyMultiSigDeployer.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
+import '@openzeppelin/contracts/utils/Create2.sol';
+
 import './MyMultiSig.sol';
 import './interfaces/IMyMultiSigDeployer.sol';
 
@@ -11,6 +13,14 @@ import './interfaces/IMyMultiSigDeployer.sol';
 ///         call here. The MyMultiSig creation bytecode lives in this contract,
 ///         not in the factory, which keeps the factory well under the
 ///         EIP-170 24,576-byte deployable-code limit.
+///
+///         Two deploy paths exist: `deployMyMultiSig` uses plain CREATE, and
+///         `deployMyMultiSigDeterministic` uses CREATE2 so the wallet address
+///         is a pure function of this deployer's address, the caller, the
+///         salt and the constructor arguments — the same inputs on any chain
+///         where this deployer sits at the same address yield the same wallet
+///         address. `predictMyMultiSigAddress` computes that address without
+///         deploying.
 contract MyMultiSigDeployer is IMyMultiSigDeployer {
   function deployMyMultiSig(
     string memory contractName_,
@@ -18,5 +28,47 @@ contract MyMultiSigDeployer is IMyMultiSigDeployer {
     uint16 threshold_
   ) external override returns (address contractAddress) {
     contractAddress = address(new MyMultiSig(contractName_, owners_, threshold_));
+  }
+
+  /// @notice Deploys a `MyMultiSig` wallet via CREATE2.
+  /// @dev    The effective salt mixes in `msg.sender`, so each caller of this
+  ///         deployer gets its own address namespace: a third party calling
+  ///         this function directly can never occupy an address that a
+  ///         factory-mediated deploy would resolve to.
+  ///         Reverts if a contract already exists at the target address
+  ///         (same caller, salt and constructor arguments).
+  /// @param salt_ Caller-chosen salt.
+  /// @param contractName_ The wallet's name (part of the EIP-712 domain).
+  /// @param owners_ The owners list.
+  /// @param threshold_ The minimum sigs required to execute a transaction.
+  /// @return contractAddress The deployed wallet address.
+  function deployMyMultiSigDeterministic(
+    bytes32 salt_,
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_
+  ) external override returns (address contractAddress) {
+    contractAddress = address(new MyMultiSig{ salt: _callerSalt(salt_) }(contractName_, owners_, threshold_));
+  }
+
+  /// @notice Predicts the address `deployMyMultiSigDeterministic` would
+  ///         deploy to for the same caller, salt and constructor arguments.
+  /// @dev    Must be called by the same account that will perform the deploy
+  ///         (the salt is namespaced by `msg.sender`).
+  function predictMyMultiSigAddress(
+    bytes32 salt_,
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_
+  ) external view override returns (address contractAddress) {
+    contractAddress = Create2.computeAddress(
+      _callerSalt(salt_),
+      keccak256(abi.encodePacked(type(MyMultiSig).creationCode, abi.encode(contractName_, owners_, threshold_)))
+    );
+  }
+
+  /// @dev Namespaces a caller-chosen salt by `msg.sender`.
+  function _callerSalt(bytes32 salt_) private view returns (bytes32) {
+    return keccak256(abi.encode(msg.sender, salt_));
   }
 }

--- a/contracts/MyMultiSigExtendedDeployer.sol
+++ b/contracts/MyMultiSigExtendedDeployer.sol
@@ -1,6 +1,8 @@
 // SPDX-License-Identifier: MIT
 pragma solidity 0.8.24;
 
+import '@openzeppelin/contracts/utils/Create2.sol';
+
 import './MyMultiSigExtended.sol';
 import './interfaces/IMyMultiSigExtendedDeployer.sol';
 
@@ -11,6 +13,13 @@ import './interfaces/IMyMultiSigExtendedDeployer.sol';
 ///         the extra delegation / 4337 / operation-byte logic).
 /// @dev    Forwards every argument — including `entryPoint_` — straight
 ///         through to the wallet's constructor.
+///
+///         Two deploy paths exist: `deployMyMultiSigExtended` uses plain
+///         CREATE, and `deployMyMultiSigExtendedDeterministic` uses CREATE2
+///         so the wallet address is a pure function of this deployer's
+///         address, the caller, the salt and the constructor arguments.
+///         `predictMyMultiSigExtendedAddress` computes that address without
+///         deploying.
 contract MyMultiSigExtendedDeployer is IMyMultiSigExtendedDeployer {
   function deployMyMultiSigExtended(
     string memory contractName_,
@@ -22,5 +31,62 @@ contract MyMultiSigExtendedDeployer is IMyMultiSigExtendedDeployer {
     contractAddress = address(
       new MyMultiSigExtended(contractName_, owners_, threshold_, isOnlyOwnerRequest_, entryPoint_)
     );
+  }
+
+  /// @notice Deploys a `MyMultiSigExtended` wallet via CREATE2.
+  /// @dev    The effective salt mixes in `msg.sender`, so each caller of this
+  ///         deployer gets its own address namespace: a third party calling
+  ///         this function directly can never occupy an address that a
+  ///         factory-mediated deploy would resolve to.
+  ///         Reverts if a contract already exists at the target address
+  ///         (same caller, salt and constructor arguments).
+  /// @param salt_ Caller-chosen salt.
+  /// @return contractAddress The deployed wallet address.
+  function deployMyMultiSigExtendedDeterministic(
+    bytes32 salt_,
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_,
+    bool isOnlyOwnerRequest_,
+    address entryPoint_
+  ) external override returns (address contractAddress) {
+    contractAddress = address(
+      new MyMultiSigExtended{ salt: _callerSalt(salt_) }(
+        contractName_,
+        owners_,
+        threshold_,
+        isOnlyOwnerRequest_,
+        entryPoint_
+      )
+    );
+  }
+
+  /// @notice Predicts the address `deployMyMultiSigExtendedDeterministic`
+  ///         would deploy to for the same caller, salt and constructor
+  ///         arguments.
+  /// @dev    Must be called by the same account that will perform the deploy
+  ///         (the salt is namespaced by `msg.sender`).
+  function predictMyMultiSigExtendedAddress(
+    bytes32 salt_,
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_,
+    bool isOnlyOwnerRequest_,
+    address entryPoint_
+  ) external view override returns (address contractAddress) {
+    contractAddress = Create2.computeAddress(
+      _callerSalt(salt_),
+      keccak256(
+        abi.encodePacked(
+          type(MyMultiSigExtended).creationCode,
+          abi.encode(contractName_, owners_, threshold_, isOnlyOwnerRequest_, entryPoint_)
+        )
+      )
+    );
+  }
+
+  /// @dev Namespaces a caller-chosen salt by `msg.sender`.
+  function _callerSalt(bytes32 salt_) private view returns (bytes32) {
+    return keccak256(abi.encode(msg.sender, salt_));
   }
 }

--- a/contracts/abstracts/MyMultiSigFactorable.sol
+++ b/contracts/abstracts/MyMultiSigFactorable.sol
@@ -166,6 +166,18 @@ abstract contract MyMultiSigFactorable {
     _multiSigCount = newCount;
   }
 
+  /// @notice The effective salt forwarded to a deployer for a
+  ///         deterministic (CREATE2) creation by `creator` with `salt`.
+  /// @dev    Mixes the creator into the salt so two creators using the same
+  ///         salt never race for the same address. The wallet address is
+  ///         fully determined by (factory address, deployer address, creator,
+  ///         salt, constructor arguments) — identical inputs on any chain
+  ///         where the factory and deployers sit at the same addresses yield
+  ///         the same wallet address.
+  function computeSalt(address creator, bytes32 salt) public pure returns (bytes32) {
+    return keccak256(abi.encode(creator, salt));
+  }
+
   /// @notice Creates a new base `MyMultiSig` wallet.
   /// @param contractName The wallet's name (shown in the EIP-712 domain).
   /// @param owners The owners list.
@@ -180,6 +192,49 @@ abstract contract MyMultiSigFactorable {
     uint256 newCount = _recordMultiSig(contractAddress, MyMultiSigFactorableModels.CreationType.SIMPLE);
 
     emit MyMultiSigCreated(msg.sender, contractAddress, newCount, contractName, owners, threshold);
+  }
+
+  /// @notice Creates a new base `MyMultiSig` wallet at a deterministic
+  ///         (CREATE2) address, predictable via `predictMultiSigAddress`.
+  /// @dev    Reverts if a wallet was already created with the same creator,
+  ///         salt and constructor arguments.
+  /// @param contractName The wallet's name (shown in the EIP-712 domain).
+  /// @param owners The owners list.
+  /// @param threshold The minimum sigs required to execute a transaction.
+  /// @param salt Creator-chosen salt.
+  function createDeterministicMultiSig(
+    string memory contractName,
+    address[] memory owners,
+    uint16 threshold,
+    bytes32 salt
+  ) public payable returns (address contractAddress) {
+    contractAddress = IMyMultiSigDeployer(myMultiSigDeployer).deployMyMultiSigDeterministic(
+      computeSalt(msg.sender, salt),
+      contractName,
+      owners,
+      threshold
+    );
+
+    uint256 newCount = _recordMultiSig(contractAddress, MyMultiSigFactorableModels.CreationType.SIMPLE);
+
+    emit MyMultiSigCreated(msg.sender, contractAddress, newCount, contractName, owners, threshold);
+  }
+
+  /// @notice Predicts the address `createDeterministicMultiSig` deploys to
+  ///         when called by `creator` with the same salt and arguments.
+  function predictMultiSigAddress(
+    address creator,
+    string memory contractName,
+    address[] memory owners,
+    uint16 threshold,
+    bytes32 salt
+  ) public view returns (address contractAddress) {
+    contractAddress = IMyMultiSigDeployer(myMultiSigDeployer).predictMyMultiSigAddress(
+      computeSalt(creator, salt),
+      contractName,
+      owners,
+      threshold
+    );
   }
 
   /// @notice Creates a new `MyMultiSigExtended` wallet via the Extended
@@ -210,6 +265,57 @@ abstract contract MyMultiSigFactorable {
     emit MyMultiSigCreated(msg.sender, contractAddress, newCount, contractName, owners, threshold);
   }
 
+  /// @notice Creates a new `MyMultiSigExtended` wallet at a deterministic
+  ///         (CREATE2) address, predictable via
+  ///         `predictMyMultiSigExtendedAddress`. Same `entryPoint` semantics
+  ///         as `createMyMultiSigExtended`.
+  /// @dev    Reverts if a wallet was already created with the same creator,
+  ///         salt and constructor arguments.
+  /// @param salt Creator-chosen salt.
+  function createDeterministicMyMultiSigExtended(
+    string memory contractName,
+    address[] memory owners,
+    uint16 threshold,
+    bool isOnlyOwnerRequest,
+    address entryPoint,
+    bytes32 salt
+  ) public payable returns (address contractAddress) {
+    contractAddress = IMyMultiSigExtendedDeployer(myMultiSigExtendedDeployer).deployMyMultiSigExtendedDeterministic(
+      computeSalt(msg.sender, salt),
+      contractName,
+      owners,
+      threshold,
+      isOnlyOwnerRequest,
+      entryPoint
+    );
+
+    uint256 newCount = _recordMultiSig(contractAddress, MyMultiSigFactorableModels.CreationType.EXTENDED);
+
+    emit MyMultiSigCreated(msg.sender, contractAddress, newCount, contractName, owners, threshold);
+  }
+
+  /// @notice Predicts the address `createDeterministicMyMultiSigExtended`
+  ///         deploys to when called by `creator` with the same salt and
+  ///         arguments.
+  function predictMyMultiSigExtendedAddress(
+    address creator,
+    string memory contractName,
+    address[] memory owners,
+    uint16 threshold,
+    bool isOnlyOwnerRequest,
+    address entryPoint,
+    bytes32 salt
+  ) public view returns (address contractAddress) {
+    contractAddress = IMyMultiSigExtendedDeployer(myMultiSigExtendedDeployer).predictMyMultiSigExtendedAddress(
+      computeSalt(creator, salt),
+      contractName,
+      owners,
+      threshold,
+      isOnlyOwnerRequest,
+      entryPoint
+    );
+  }
+
   /// @notice Creates a new `MyMultiSigExtended`-class wallet via the Advanced
   ///         deployer. Currently routes to the Extended deployer (the
   ///         wallet bytecode is identical); the factory
@@ -234,5 +340,57 @@ abstract contract MyMultiSigFactorable {
     uint256 newCount = _recordMultiSig(contractAddress, MyMultiSigFactorableModels.CreationType.ADVANCED);
 
     emit MyMultiSigCreated(msg.sender, contractAddress, newCount, contractName, owners, threshold);
+  }
+
+  /// @notice Creates a new Advanced wallet at a deterministic (CREATE2)
+  ///         address, predictable via `predictMyMultiSigAdvancedAddress`.
+  ///         Same `entryPoint` semantics as `createMyMultiSigExtended`.
+  /// @dev    Reverts if a wallet was already created with the same creator,
+  ///         salt and constructor arguments. Advanced deploys live in the
+  ///         Advanced deployer's salt namespace, so they never collide with
+  ///         Extended deploys sharing the same salt and arguments.
+  /// @param salt Creator-chosen salt.
+  function createDeterministicMyMultiSigAdvanced(
+    string memory contractName,
+    address[] memory owners,
+    uint16 threshold,
+    bool isOnlyOwnerRequest,
+    address entryPoint,
+    bytes32 salt
+  ) public payable returns (address contractAddress) {
+    contractAddress = IMyMultiSigAdvancedDeployer(myMultiSigAdvancedDeployer).deployMyMultiSigAdvancedDeterministic(
+      computeSalt(msg.sender, salt),
+      contractName,
+      owners,
+      threshold,
+      isOnlyOwnerRequest,
+      entryPoint
+    );
+
+    uint256 newCount = _recordMultiSig(contractAddress, MyMultiSigFactorableModels.CreationType.ADVANCED);
+
+    emit MyMultiSigCreated(msg.sender, contractAddress, newCount, contractName, owners, threshold);
+  }
+
+  /// @notice Predicts the address `createDeterministicMyMultiSigAdvanced`
+  ///         deploys to when called by `creator` with the same salt and
+  ///         arguments.
+  function predictMyMultiSigAdvancedAddress(
+    address creator,
+    string memory contractName,
+    address[] memory owners,
+    uint16 threshold,
+    bool isOnlyOwnerRequest,
+    address entryPoint,
+    bytes32 salt
+  ) public view returns (address contractAddress) {
+    contractAddress = IMyMultiSigAdvancedDeployer(myMultiSigAdvancedDeployer).predictMyMultiSigAdvancedAddress(
+      computeSalt(creator, salt),
+      contractName,
+      owners,
+      threshold,
+      isOnlyOwnerRequest,
+      entryPoint
+    );
   }
 }

--- a/contracts/interfaces/IMyMultiSigAdvancedDeployer.sol
+++ b/contracts/interfaces/IMyMultiSigAdvancedDeployer.sol
@@ -9,4 +9,22 @@ interface IMyMultiSigAdvancedDeployer {
     bool isOnlyOwnerRequest_,
     address entryPoint_
   ) external returns (address contractAddress);
+
+  function deployMyMultiSigAdvancedDeterministic(
+    bytes32 salt_,
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_,
+    bool isOnlyOwnerRequest_,
+    address entryPoint_
+  ) external returns (address contractAddress);
+
+  function predictMyMultiSigAdvancedAddress(
+    bytes32 salt_,
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_,
+    bool isOnlyOwnerRequest_,
+    address entryPoint_
+  ) external view returns (address contractAddress);
 }

--- a/contracts/interfaces/IMyMultiSigDeployer.sol
+++ b/contracts/interfaces/IMyMultiSigDeployer.sol
@@ -7,4 +7,18 @@ interface IMyMultiSigDeployer {
     address[] memory owners_,
     uint16 threshold_
   ) external returns (address contractAddress);
+
+  function deployMyMultiSigDeterministic(
+    bytes32 salt_,
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_
+  ) external returns (address contractAddress);
+
+  function predictMyMultiSigAddress(
+    bytes32 salt_,
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_
+  ) external view returns (address contractAddress);
 }

--- a/contracts/interfaces/IMyMultiSigExtendedDeployer.sol
+++ b/contracts/interfaces/IMyMultiSigExtendedDeployer.sol
@@ -9,4 +9,22 @@ interface IMyMultiSigExtendedDeployer {
     bool isOnlyOwnerRequest_,
     address entryPoint_
   ) external returns (address contractAddress);
+
+  function deployMyMultiSigExtendedDeterministic(
+    bytes32 salt_,
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_,
+    bool isOnlyOwnerRequest_,
+    address entryPoint_
+  ) external returns (address contractAddress);
+
+  function predictMyMultiSigExtendedAddress(
+    bytes32 salt_,
+    string memory contractName_,
+    address[] memory owners_,
+    uint16 threshold_,
+    bool isOnlyOwnerRequest_,
+    address entryPoint_
+  ) external view returns (address contractAddress);
 }

--- a/contracts/test/MyMultiSigFactory.create2.t.sol
+++ b/contracts/test/MyMultiSigFactory.create2.t.sol
@@ -1,0 +1,179 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import { Test } from 'forge-std/Test.sol';
+
+import { MyMultiSig } from '../MyMultiSig.sol';
+import { MyMultiSigExtended } from '../MyMultiSigExtended.sol';
+import { MyMultiSigFactory } from '../MyMultiSigFactory.sol';
+import { MyMultiSigDeployer } from '../MyMultiSigDeployer.sol';
+import { MyMultiSigExtendedDeployer } from '../MyMultiSigExtendedDeployer.sol';
+import { MyMultiSigAdvancedDeployer } from '../MyMultiSigAdvancedDeployer.sol';
+import { MyMultiSigFactorableModels } from '../libs/MyMultiSigFactorableModels.sol';
+
+contract TestMyMultiSigFactory_create2 is Test {
+  string constant CONTRACT_NAME = 'MyMultiSig';
+  address constant ENTRY_POINT = 0x0000000071727dE22E5e9D8Bde0DfeC0cEB6A7d7;
+  bytes32 constant SALT = keccak256('mymultisig.app/test-salt');
+
+  MyMultiSigFactory public factory;
+  MyMultiSigDeployer public simpleDeployer;
+  MyMultiSigExtendedDeployer public extendedDeployer;
+  MyMultiSigAdvancedDeployer public advancedDeployer;
+
+  address public alice = vm.addr(1_001);
+  address public bob = vm.addr(1_002);
+  address[] public owners;
+
+  event MyMultiSigCreated(
+    address indexed creator,
+    address indexed contractAddress,
+    uint256 indexed contractIndex,
+    string contractName,
+    address[] originalOwners,
+    uint16 threshold
+  );
+
+  function setUp() public {
+    simpleDeployer = new MyMultiSigDeployer();
+    extendedDeployer = new MyMultiSigExtendedDeployer();
+    advancedDeployer = new MyMultiSigAdvancedDeployer(address(extendedDeployer));
+    factory = new MyMultiSigFactory(address(simpleDeployer), address(extendedDeployer), address(advancedDeployer));
+
+    owners.push(vm.addr(1));
+    owners.push(vm.addr(2));
+    owners.push(vm.addr(3));
+  }
+
+  function test_create2_simple_deploysAtPredictedAddress() public {
+    address predicted = factory.predictMultiSigAddress(alice, CONTRACT_NAME, owners, 2, SALT);
+
+    vm.expectEmit(true, true, true, true, address(factory));
+    emit MyMultiSigCreated(alice, predicted, 1, CONTRACT_NAME, owners, 2);
+    vm.prank(alice);
+    address deployed = factory.createDeterministicMultiSig(CONTRACT_NAME, owners, 2, SALT);
+
+    assertEq(deployed, predicted);
+    assertGt(deployed.code.length, 0);
+    assertEq(MyMultiSig(payable(deployed)).threshold(), 2);
+    assertEq(factory.multiSig(0), deployed);
+    assertEq(factory.multiSigCount(), 1);
+    assertEq(factory.simpleCount(), 1);
+    assertTrue(factory.creationTypeOf(deployed) == MyMultiSigFactorableModels.CreationType.SIMPLE);
+  }
+
+  function test_create2_extended_deploysAtPredictedAddress() public {
+    address predicted = factory.predictMyMultiSigExtendedAddress(alice, CONTRACT_NAME, owners, 2, true, ENTRY_POINT, SALT);
+
+    vm.prank(alice);
+    address deployed = factory.createDeterministicMyMultiSigExtended(CONTRACT_NAME, owners, 2, true, ENTRY_POINT, SALT);
+
+    assertEq(deployed, predicted);
+    assertGt(deployed.code.length, 0);
+    assertEq(address(MyMultiSigExtended(payable(deployed)).ENTRY_POINT()), ENTRY_POINT);
+    assertEq(factory.extendedCount(), 1);
+    assertTrue(factory.creationTypeOf(deployed) == MyMultiSigFactorableModels.CreationType.EXTENDED);
+    assertTrue(factory.isExtended(deployed));
+  }
+
+  function test_create2_advanced_deploysAtPredictedAddress() public {
+    address predicted = factory.predictMyMultiSigAdvancedAddress(alice, CONTRACT_NAME, owners, 2, true, ENTRY_POINT, SALT);
+
+    vm.prank(alice);
+    address deployed = factory.createDeterministicMyMultiSigAdvanced(CONTRACT_NAME, owners, 2, true, ENTRY_POINT, SALT);
+
+    assertEq(deployed, predicted);
+    assertGt(deployed.code.length, 0);
+    assertEq(factory.advancedCount(), 1);
+    assertTrue(factory.creationTypeOf(deployed) == MyMultiSigFactorableModels.CreationType.ADVANCED);
+  }
+
+  function test_create2_advancedAndExtended_sameSaltDoNotCollide() public {
+    address predictedExtended = factory.predictMyMultiSigExtendedAddress(
+      alice,
+      CONTRACT_NAME,
+      owners,
+      2,
+      true,
+      ENTRY_POINT,
+      SALT
+    );
+    address predictedAdvanced = factory.predictMyMultiSigAdvancedAddress(
+      alice,
+      CONTRACT_NAME,
+      owners,
+      2,
+      true,
+      ENTRY_POINT,
+      SALT
+    );
+    assertTrue(predictedExtended != predictedAdvanced);
+
+    vm.startPrank(alice);
+    address extendedWallet = factory.createDeterministicMyMultiSigExtended(
+      CONTRACT_NAME,
+      owners,
+      2,
+      true,
+      ENTRY_POINT,
+      SALT
+    );
+    address advancedWallet = factory.createDeterministicMyMultiSigAdvanced(
+      CONTRACT_NAME,
+      owners,
+      2,
+      true,
+      ENTRY_POINT,
+      SALT
+    );
+    vm.stopPrank();
+
+    assertEq(extendedWallet, predictedExtended);
+    assertEq(advancedWallet, predictedAdvanced);
+  }
+
+  function test_create2_sameCreatorSameSaltReverts() public {
+    vm.prank(alice);
+    factory.createDeterministicMultiSig(CONTRACT_NAME, owners, 2, SALT);
+
+    vm.prank(alice);
+    vm.expectRevert();
+    factory.createDeterministicMultiSig(CONTRACT_NAME, owners, 2, SALT);
+  }
+
+  function test_create2_differentCreatorsGetDifferentAddresses() public {
+    address predictedAlice = factory.predictMultiSigAddress(alice, CONTRACT_NAME, owners, 2, SALT);
+    address predictedBob = factory.predictMultiSigAddress(bob, CONTRACT_NAME, owners, 2, SALT);
+    assertTrue(predictedAlice != predictedBob);
+
+    vm.prank(alice);
+    assertEq(factory.createDeterministicMultiSig(CONTRACT_NAME, owners, 2, SALT), predictedAlice);
+    vm.prank(bob);
+    assertEq(factory.createDeterministicMultiSig(CONTRACT_NAME, owners, 2, SALT), predictedBob);
+  }
+
+  function test_create2_directDeployerCallCannotSquatFactoryAddress() public {
+    address predicted = factory.predictMultiSigAddress(alice, CONTRACT_NAME, owners, 2, SALT);
+
+    // A third party replays the factory's derived salt directly against the
+    // deployer; the deployer namespaces salts by caller, so the address it
+    // deploys to differs from the factory-mediated one.
+    bytes32 factorySalt = factory.computeSalt(alice, SALT);
+    vm.prank(bob);
+    address squatted = simpleDeployer.deployMyMultiSigDeterministic(factorySalt, CONTRACT_NAME, owners, 2);
+    assertTrue(squatted != predicted);
+
+    vm.prank(alice);
+    address deployed = factory.createDeterministicMultiSig(CONTRACT_NAME, owners, 2, SALT);
+    assertEq(deployed, predicted);
+  }
+
+  function test_create2_predictIsPureFunctionOfInputs() public {
+    address before = factory.predictMultiSigAddress(alice, CONTRACT_NAME, owners, 2, SALT);
+    vm.roll(block.number + 100);
+    vm.warp(block.timestamp + 1 days);
+    assertEq(factory.predictMultiSigAddress(alice, CONTRACT_NAME, owners, 2, SALT), before);
+    assertTrue(factory.predictMultiSigAddress(alice, CONTRACT_NAME, owners, 2, keccak256('other-salt')) != before);
+    assertTrue(factory.predictMultiSigAddress(alice, CONTRACT_NAME, owners, 3, SALT) != before);
+  }
+}

--- a/scripts/buildTypes.ts
+++ b/scripts/buildTypes.ts
@@ -3,27 +3,38 @@ import { existsSync, rmSync, mkdirSync, copyFileSync, readdirSync } from 'fs'
 
 import constants from '../constants'
 
+// The committed `types/` layout is flat: wallet/factory/deployer classes from
+// `contracts/`, their interfaces from `contracts/interfaces/` and the factory
+// abstract from `contracts/abstracts/` all sit side by side.
+const TYPE_SOURCE_DIRS = [
+  'typechain-types/contracts/',
+  'typechain-types/contracts/interfaces/',
+  'typechain-types/contracts/abstracts/',
+]
+
 async function main() {
   if (existsSync('types')) rmSync('types', { recursive: true })
 
-  // get all types paths from typechain-types
-  const allTypesPaths = readdirSync('typechain-types/contracts/')
-  const filteredTypesPaths = allTypesPaths.filter(
-    (path: string) => path.includes(constants.CONTRACT_NAME) && !path.includes('.t.sol')
-  )
-  console.log('\x1b[32m', 'Building typess for ', filteredTypesPaths.length, '\x1b[0m', ' contracts')
-  filteredTypesPaths.forEach((file: string) => {
-    const path = 'typechain-types/contracts/' + file
-    // detect if file exists
-    if (existsSync(path)) {
-      // if types/ does not exist, create it
-      if (!existsSync('types')) mkdirSync('types')
-      // copy file
-      const newFilePath = 'types/' + file
-      copyFileSync(path, newFilePath)
-      console.log('\x1b[32m', 'Build types for ', '\x1b[0m', file, ' to ', '\x1b[34m', newFilePath, '\x1b[0m')
-    }
-  })
+  for (const sourceDir of TYPE_SOURCE_DIRS) {
+    // get all types paths from typechain-types
+    const allTypesPaths = readdirSync(sourceDir)
+    const filteredTypesPaths = allTypesPaths.filter(
+      (path: string) => path.includes(constants.CONTRACT_NAME) && !path.includes('.t.sol')
+    )
+    console.log('\x1b[32m', 'Building typess for ', filteredTypesPaths.length, '\x1b[0m', ' contracts')
+    filteredTypesPaths.forEach((file: string) => {
+      const path = sourceDir + file
+      // detect if file exists
+      if (existsSync(path)) {
+        // if types/ does not exist, create it
+        if (!existsSync('types')) mkdirSync('types')
+        // copy file
+        const newFilePath = 'types/' + file
+        copyFileSync(path, newFilePath)
+        console.log('\x1b[32m', 'Build types for ', '\x1b[0m', file, ' to ', '\x1b[34m', newFilePath, '\x1b[0m')
+      }
+    })
+  }
   console.log('\x1b[32m', 'Done building types', '\x1b[0m')
 }
 

--- a/test/MyMultiSigFactoryCreate2.test.ts
+++ b/test/MyMultiSigFactoryCreate2.test.ts
@@ -1,0 +1,5 @@
+import { MyMultiSigFactoryCreate2Tests } from './shared/tests'
+
+describe('MyMultiSig - Factory CREATE2 deterministic wallets (v0.5.0)', function () {
+  MyMultiSigFactoryCreate2Tests()
+})

--- a/test/shared/tests.ts
+++ b/test/shared/tests.ts
@@ -3068,3 +3068,125 @@ export async function MyMultiSigFactoryTests() {
     })
   })
 }
+
+export async function MyMultiSigFactoryCreate2Tests() {
+  let owner01: any
+  let user01: any
+  let deployment: any
+  let factory: any
+  let owners: string[]
+
+  const SALT = ethers.utils.id('mymultisig.app/test-salt')
+
+  describe('MyMultiSig - Factory CREATE2 Tests', function () {
+    before(async function () {
+      ;[, owner01, , , user01] = await Helper.setupProviderAndAccount()
+    })
+
+    beforeEach(async function () {
+      deployment = await Helper.setupContract(Helper.CONTRACT_FACTORY_NAME, [owner01.address], 1, true)
+      factory = deployment.contract
+      owners = [owner01.address]
+    })
+
+    it('createDeterministicMultiSig deploys at the predicted address and records SIMPLE', async function () {
+      const predicted = await factory.predictMultiSigAddress(owner01.address, Helper.CONTRACT_NAME, owners, 1, SALT)
+      const tx = await factory
+        .connect(owner01)
+        .createDeterministicMultiSig(Helper.CONTRACT_NAME, owners, 1, SALT)
+      await expect(tx)
+        .to.emit(factory, 'MyMultiSigCreated')
+        .withArgs(owner01.address, predicted, 1, Helper.CONTRACT_NAME, owners, 1)
+      expect(await factory.multiSig(0)).to.be.equal(predicted)
+      expect(await factory.simpleCount()).to.be.equal(1)
+      expect(await factory.creationTypeOf(predicted)).to.be.equal(0) // SIMPLE
+      const wallet = await ethers.getContractAt('MyMultiSig', predicted)
+      expect(await wallet.threshold()).to.be.equal(1)
+    })
+
+    it('createDeterministicMyMultiSigExtended deploys at the predicted address and records EXTENDED', async function () {
+      const predicted = await factory.predictMyMultiSigExtendedAddress(
+        owner01.address,
+        Helper.CONTRACT_NAME,
+        owners,
+        1,
+        Helper.DEFAULT_ALLOW_ONLY_OWNER,
+        Helper.ENTRY_POINT_V07_ADDRESS,
+        SALT,
+      )
+      await factory
+        .connect(owner01)
+        .createDeterministicMyMultiSigExtended(
+          Helper.CONTRACT_NAME,
+          owners,
+          1,
+          Helper.DEFAULT_ALLOW_ONLY_OWNER,
+          Helper.ENTRY_POINT_V07_ADDRESS,
+          SALT,
+        )
+      expect(await factory.multiSig(0)).to.be.equal(predicted)
+      expect(await factory.extendedCount()).to.be.equal(1)
+      expect(await factory.creationTypeOf(predicted)).to.be.equal(1) // EXTENDED
+      expect(await factory.isExtended(predicted)).to.be.true
+      const wallet = await ethers.getContractAt('MyMultiSigExtended', predicted)
+      expect((await wallet.ENTRY_POINT()).toLowerCase()).to.be.equal(Helper.ENTRY_POINT_V07_ADDRESS)
+    })
+
+    it('createDeterministicMyMultiSigAdvanced deploys at the predicted address, distinct from Extended', async function () {
+      const predictedAdvanced = await factory.predictMyMultiSigAdvancedAddress(
+        owner01.address,
+        Helper.CONTRACT_NAME,
+        owners,
+        1,
+        Helper.DEFAULT_ALLOW_ONLY_OWNER,
+        Helper.ENTRY_POINT_V07_ADDRESS,
+        SALT,
+      )
+      const predictedExtended = await factory.predictMyMultiSigExtendedAddress(
+        owner01.address,
+        Helper.CONTRACT_NAME,
+        owners,
+        1,
+        Helper.DEFAULT_ALLOW_ONLY_OWNER,
+        Helper.ENTRY_POINT_V07_ADDRESS,
+        SALT,
+      )
+      expect(predictedAdvanced).to.not.be.equal(predictedExtended)
+      await factory
+        .connect(owner01)
+        .createDeterministicMyMultiSigAdvanced(
+          Helper.CONTRACT_NAME,
+          owners,
+          1,
+          Helper.DEFAULT_ALLOW_ONLY_OWNER,
+          Helper.ENTRY_POINT_V07_ADDRESS,
+          SALT,
+        )
+      expect(await factory.multiSig(0)).to.be.equal(predictedAdvanced)
+      expect(await factory.advancedCount()).to.be.equal(1)
+      expect(await factory.creationTypeOf(predictedAdvanced)).to.be.equal(2) // ADVANCED
+    })
+
+    it('reverts when the same creator reuses a salt with identical arguments', async function () {
+      await factory.connect(owner01).createDeterministicMultiSig(Helper.CONTRACT_NAME, owners, 1, SALT)
+      await expect(factory.connect(owner01).createDeterministicMultiSig(Helper.CONTRACT_NAME, owners, 1, SALT)).to.be
+        .reverted
+    })
+
+    it('gives different creators different addresses for the same salt and arguments', async function () {
+      const predictedOwner = await factory.predictMultiSigAddress(
+        owner01.address,
+        Helper.CONTRACT_NAME,
+        owners,
+        1,
+        SALT,
+      )
+      const predictedUser = await factory.predictMultiSigAddress(user01.address, Helper.CONTRACT_NAME, owners, 1, SALT)
+      expect(predictedOwner).to.not.be.equal(predictedUser)
+      await factory.connect(owner01).createDeterministicMultiSig(Helper.CONTRACT_NAME, owners, 1, SALT)
+      await factory.connect(user01).createDeterministicMultiSig(Helper.CONTRACT_NAME, owners, 1, SALT)
+      expect(await factory.multiSig(0)).to.be.equal(predictedOwner)
+      expect(await factory.multiSig(1)).to.be.equal(predictedUser)
+    })
+  })
+}

--- a/types/IMyMultiSigAdvancedDeployer.ts
+++ b/types/IMyMultiSigAdvancedDeployer.ts
@@ -21,15 +21,20 @@ import type {
   TypedListener,
   OnEvent,
   PromiseOrValue,
-} from "../common";
+} from "../../common";
 
 export interface IMyMultiSigAdvancedDeployerInterface extends utils.Interface {
   functions: {
     "deployMyMultiSigAdvanced(string,address[],uint16,bool,address)": FunctionFragment;
+    "deployMyMultiSigAdvancedDeterministic(bytes32,string,address[],uint16,bool,address)": FunctionFragment;
+    "predictMyMultiSigAdvancedAddress(bytes32,string,address[],uint16,bool,address)": FunctionFragment;
   };
 
   getFunction(
-    nameOrSignatureOrTopic: "deployMyMultiSigAdvanced"
+    nameOrSignatureOrTopic:
+      | "deployMyMultiSigAdvanced"
+      | "deployMyMultiSigAdvancedDeterministic"
+      | "predictMyMultiSigAdvancedAddress"
   ): FunctionFragment;
 
   encodeFunctionData(
@@ -42,9 +47,39 @@ export interface IMyMultiSigAdvancedDeployerInterface extends utils.Interface {
       PromiseOrValue<string>
     ]
   ): string;
+  encodeFunctionData(
+    functionFragment: "deployMyMultiSigAdvancedDeterministic",
+    values: [
+      PromiseOrValue<BytesLike>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>
+    ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "predictMyMultiSigAdvancedAddress",
+    values: [
+      PromiseOrValue<BytesLike>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>
+    ]
+  ): string;
 
   decodeFunctionResult(
     functionFragment: "deployMyMultiSigAdvanced",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "deployMyMultiSigAdvancedDeterministic",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "predictMyMultiSigAdvancedAddress",
     data: BytesLike
   ): Result;
 
@@ -86,6 +121,26 @@ export interface IMyMultiSigAdvancedDeployer extends BaseContract {
       entryPoint_: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
+
+    deployMyMultiSigAdvancedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    predictMyMultiSigAdvancedAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<[string] & { contractAddress: string }>;
   };
 
   deployMyMultiSigAdvanced(
@@ -97,8 +152,48 @@ export interface IMyMultiSigAdvancedDeployer extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  deployMyMultiSigAdvancedDeterministic(
+    salt_: PromiseOrValue<BytesLike>,
+    contractName_: PromiseOrValue<string>,
+    owners_: PromiseOrValue<string>[],
+    threshold_: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+    entryPoint_: PromiseOrValue<string>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  predictMyMultiSigAdvancedAddress(
+    salt_: PromiseOrValue<BytesLike>,
+    contractName_: PromiseOrValue<string>,
+    owners_: PromiseOrValue<string>[],
+    threshold_: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+    entryPoint_: PromiseOrValue<string>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   callStatic: {
     deployMyMultiSigAdvanced(
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    deployMyMultiSigAdvancedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    predictMyMultiSigAdvancedAddress(
+      salt_: PromiseOrValue<BytesLike>,
       contractName_: PromiseOrValue<string>,
       owners_: PromiseOrValue<string>[],
       threshold_: PromiseOrValue<BigNumberish>,
@@ -119,6 +214,26 @@ export interface IMyMultiSigAdvancedDeployer extends BaseContract {
       entryPoint_: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
+
+    deployMyMultiSigAdvancedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    predictMyMultiSigAdvancedAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
   };
 
   populateTransaction: {
@@ -129,6 +244,26 @@ export interface IMyMultiSigAdvancedDeployer extends BaseContract {
       isOnlyOwnerRequest_: PromiseOrValue<boolean>,
       entryPoint_: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    deployMyMultiSigAdvancedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    predictMyMultiSigAdvancedAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
   };
 }

--- a/types/IMyMultiSigDeployer.ts
+++ b/types/IMyMultiSigDeployer.ts
@@ -21,14 +21,21 @@ import type {
   TypedListener,
   OnEvent,
   PromiseOrValue,
-} from "../common";
+} from "../../common";
 
 export interface IMyMultiSigDeployerInterface extends utils.Interface {
   functions: {
     "deployMyMultiSig(string,address[],uint16)": FunctionFragment;
+    "deployMyMultiSigDeterministic(bytes32,string,address[],uint16)": FunctionFragment;
+    "predictMyMultiSigAddress(bytes32,string,address[],uint16)": FunctionFragment;
   };
 
-  getFunction(nameOrSignatureOrTopic: "deployMyMultiSig"): FunctionFragment;
+  getFunction(
+    nameOrSignatureOrTopic:
+      | "deployMyMultiSig"
+      | "deployMyMultiSigDeterministic"
+      | "predictMyMultiSigAddress"
+  ): FunctionFragment;
 
   encodeFunctionData(
     functionFragment: "deployMyMultiSig",
@@ -38,9 +45,35 @@ export interface IMyMultiSigDeployerInterface extends utils.Interface {
       PromiseOrValue<BigNumberish>
     ]
   ): string;
+  encodeFunctionData(
+    functionFragment: "deployMyMultiSigDeterministic",
+    values: [
+      PromiseOrValue<BytesLike>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>
+    ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "predictMyMultiSigAddress",
+    values: [
+      PromiseOrValue<BytesLike>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>
+    ]
+  ): string;
 
   decodeFunctionResult(
     functionFragment: "deployMyMultiSig",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "deployMyMultiSigDeterministic",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "predictMyMultiSigAddress",
     data: BytesLike
   ): Result;
 
@@ -80,6 +113,22 @@ export interface IMyMultiSigDeployer extends BaseContract {
       threshold_: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
+
+    deployMyMultiSigDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    predictMyMultiSigAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: CallOverrides
+    ): Promise<[string] & { contractAddress: string }>;
   };
 
   deployMyMultiSig(
@@ -89,8 +138,40 @@ export interface IMyMultiSigDeployer extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  deployMyMultiSigDeterministic(
+    salt_: PromiseOrValue<BytesLike>,
+    contractName_: PromiseOrValue<string>,
+    owners_: PromiseOrValue<string>[],
+    threshold_: PromiseOrValue<BigNumberish>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  predictMyMultiSigAddress(
+    salt_: PromiseOrValue<BytesLike>,
+    contractName_: PromiseOrValue<string>,
+    owners_: PromiseOrValue<string>[],
+    threshold_: PromiseOrValue<BigNumberish>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   callStatic: {
     deployMyMultiSig(
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    deployMyMultiSigDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    predictMyMultiSigAddress(
+      salt_: PromiseOrValue<BytesLike>,
       contractName_: PromiseOrValue<string>,
       owners_: PromiseOrValue<string>[],
       threshold_: PromiseOrValue<BigNumberish>,
@@ -107,6 +188,22 @@ export interface IMyMultiSigDeployer extends BaseContract {
       threshold_: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
+
+    deployMyMultiSigDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    predictMyMultiSigAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
   };
 
   populateTransaction: {
@@ -115,6 +212,22 @@ export interface IMyMultiSigDeployer extends BaseContract {
       owners_: PromiseOrValue<string>[],
       threshold_: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    deployMyMultiSigDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    predictMyMultiSigAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
   };
 }

--- a/types/IMyMultiSigExtendedDeployer.ts
+++ b/types/IMyMultiSigExtendedDeployer.ts
@@ -21,15 +21,20 @@ import type {
   TypedListener,
   OnEvent,
   PromiseOrValue,
-} from "../common";
+} from "../../common";
 
 export interface IMyMultiSigExtendedDeployerInterface extends utils.Interface {
   functions: {
     "deployMyMultiSigExtended(string,address[],uint16,bool,address)": FunctionFragment;
+    "deployMyMultiSigExtendedDeterministic(bytes32,string,address[],uint16,bool,address)": FunctionFragment;
+    "predictMyMultiSigExtendedAddress(bytes32,string,address[],uint16,bool,address)": FunctionFragment;
   };
 
   getFunction(
-    nameOrSignatureOrTopic: "deployMyMultiSigExtended"
+    nameOrSignatureOrTopic:
+      | "deployMyMultiSigExtended"
+      | "deployMyMultiSigExtendedDeterministic"
+      | "predictMyMultiSigExtendedAddress"
   ): FunctionFragment;
 
   encodeFunctionData(
@@ -42,9 +47,39 @@ export interface IMyMultiSigExtendedDeployerInterface extends utils.Interface {
       PromiseOrValue<string>
     ]
   ): string;
+  encodeFunctionData(
+    functionFragment: "deployMyMultiSigExtendedDeterministic",
+    values: [
+      PromiseOrValue<BytesLike>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>
+    ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "predictMyMultiSigExtendedAddress",
+    values: [
+      PromiseOrValue<BytesLike>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>
+    ]
+  ): string;
 
   decodeFunctionResult(
     functionFragment: "deployMyMultiSigExtended",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "deployMyMultiSigExtendedDeterministic",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "predictMyMultiSigExtendedAddress",
     data: BytesLike
   ): Result;
 
@@ -86,6 +121,26 @@ export interface IMyMultiSigExtendedDeployer extends BaseContract {
       entryPoint_: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
+
+    deployMyMultiSigExtendedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    predictMyMultiSigExtendedAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<[string] & { contractAddress: string }>;
   };
 
   deployMyMultiSigExtended(
@@ -97,8 +152,48 @@ export interface IMyMultiSigExtendedDeployer extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  deployMyMultiSigExtendedDeterministic(
+    salt_: PromiseOrValue<BytesLike>,
+    contractName_: PromiseOrValue<string>,
+    owners_: PromiseOrValue<string>[],
+    threshold_: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+    entryPoint_: PromiseOrValue<string>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  predictMyMultiSigExtendedAddress(
+    salt_: PromiseOrValue<BytesLike>,
+    contractName_: PromiseOrValue<string>,
+    owners_: PromiseOrValue<string>[],
+    threshold_: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+    entryPoint_: PromiseOrValue<string>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   callStatic: {
     deployMyMultiSigExtended(
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    deployMyMultiSigExtendedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    predictMyMultiSigExtendedAddress(
+      salt_: PromiseOrValue<BytesLike>,
       contractName_: PromiseOrValue<string>,
       owners_: PromiseOrValue<string>[],
       threshold_: PromiseOrValue<BigNumberish>,
@@ -119,6 +214,26 @@ export interface IMyMultiSigExtendedDeployer extends BaseContract {
       entryPoint_: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
+
+    deployMyMultiSigExtendedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    predictMyMultiSigExtendedAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
   };
 
   populateTransaction: {
@@ -129,6 +244,26 @@ export interface IMyMultiSigExtendedDeployer extends BaseContract {
       isOnlyOwnerRequest_: PromiseOrValue<boolean>,
       entryPoint_: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    deployMyMultiSigExtendedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    predictMyMultiSigExtendedAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
   };
 }

--- a/types/MyMultiSigAdvancedDeployer.ts
+++ b/types/MyMultiSigAdvancedDeployer.ts
@@ -26,11 +26,17 @@ import type {
 export interface MyMultiSigAdvancedDeployerInterface extends utils.Interface {
   functions: {
     "deployMyMultiSigAdvanced(string,address[],uint16,bool,address)": FunctionFragment;
+    "deployMyMultiSigAdvancedDeterministic(bytes32,string,address[],uint16,bool,address)": FunctionFragment;
     "extendedDeployer()": FunctionFragment;
+    "predictMyMultiSigAdvancedAddress(bytes32,string,address[],uint16,bool,address)": FunctionFragment;
   };
 
   getFunction(
-    nameOrSignatureOrTopic: "deployMyMultiSigAdvanced" | "extendedDeployer"
+    nameOrSignatureOrTopic:
+      | "deployMyMultiSigAdvanced"
+      | "deployMyMultiSigAdvancedDeterministic"
+      | "extendedDeployer"
+      | "predictMyMultiSigAdvancedAddress"
   ): FunctionFragment;
 
   encodeFunctionData(
@@ -44,8 +50,30 @@ export interface MyMultiSigAdvancedDeployerInterface extends utils.Interface {
     ]
   ): string;
   encodeFunctionData(
+    functionFragment: "deployMyMultiSigAdvancedDeterministic",
+    values: [
+      PromiseOrValue<BytesLike>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>
+    ]
+  ): string;
+  encodeFunctionData(
     functionFragment: "extendedDeployer",
     values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "predictMyMultiSigAdvancedAddress",
+    values: [
+      PromiseOrValue<BytesLike>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>
+    ]
   ): string;
 
   decodeFunctionResult(
@@ -53,7 +81,15 @@ export interface MyMultiSigAdvancedDeployerInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
+    functionFragment: "deployMyMultiSigAdvancedDeterministic",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "extendedDeployer",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "predictMyMultiSigAdvancedAddress",
     data: BytesLike
   ): Result;
 
@@ -96,7 +132,27 @@ export interface MyMultiSigAdvancedDeployer extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
+    deployMyMultiSigAdvancedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
     extendedDeployer(overrides?: CallOverrides): Promise<[string]>;
+
+    predictMyMultiSigAdvancedAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<[string] & { contractAddress: string }>;
   };
 
   deployMyMultiSigAdvanced(
@@ -108,7 +164,27 @@ export interface MyMultiSigAdvancedDeployer extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  deployMyMultiSigAdvancedDeterministic(
+    salt_: PromiseOrValue<BytesLike>,
+    contractName_: PromiseOrValue<string>,
+    owners_: PromiseOrValue<string>[],
+    threshold_: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+    entryPoint_: PromiseOrValue<string>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
   extendedDeployer(overrides?: CallOverrides): Promise<string>;
+
+  predictMyMultiSigAdvancedAddress(
+    salt_: PromiseOrValue<BytesLike>,
+    contractName_: PromiseOrValue<string>,
+    owners_: PromiseOrValue<string>[],
+    threshold_: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+    entryPoint_: PromiseOrValue<string>,
+    overrides?: CallOverrides
+  ): Promise<string>;
 
   callStatic: {
     deployMyMultiSigAdvanced(
@@ -120,7 +196,27 @@ export interface MyMultiSigAdvancedDeployer extends BaseContract {
       overrides?: CallOverrides
     ): Promise<string>;
 
+    deployMyMultiSigAdvancedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
     extendedDeployer(overrides?: CallOverrides): Promise<string>;
+
+    predictMyMultiSigAdvancedAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<string>;
   };
 
   filters: {};
@@ -135,7 +231,27 @@ export interface MyMultiSigAdvancedDeployer extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
+    deployMyMultiSigAdvancedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
     extendedDeployer(overrides?: CallOverrides): Promise<BigNumber>;
+
+    predictMyMultiSigAdvancedAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
   };
 
   populateTransaction: {
@@ -148,6 +264,26 @@ export interface MyMultiSigAdvancedDeployer extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
+    deployMyMultiSigAdvancedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
     extendedDeployer(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
+    predictMyMultiSigAdvancedAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
   };
 }

--- a/types/MyMultiSigDeployer.ts
+++ b/types/MyMultiSigDeployer.ts
@@ -26,9 +26,16 @@ import type {
 export interface MyMultiSigDeployerInterface extends utils.Interface {
   functions: {
     "deployMyMultiSig(string,address[],uint16)": FunctionFragment;
+    "deployMyMultiSigDeterministic(bytes32,string,address[],uint16)": FunctionFragment;
+    "predictMyMultiSigAddress(bytes32,string,address[],uint16)": FunctionFragment;
   };
 
-  getFunction(nameOrSignatureOrTopic: "deployMyMultiSig"): FunctionFragment;
+  getFunction(
+    nameOrSignatureOrTopic:
+      | "deployMyMultiSig"
+      | "deployMyMultiSigDeterministic"
+      | "predictMyMultiSigAddress"
+  ): FunctionFragment;
 
   encodeFunctionData(
     functionFragment: "deployMyMultiSig",
@@ -38,9 +45,35 @@ export interface MyMultiSigDeployerInterface extends utils.Interface {
       PromiseOrValue<BigNumberish>
     ]
   ): string;
+  encodeFunctionData(
+    functionFragment: "deployMyMultiSigDeterministic",
+    values: [
+      PromiseOrValue<BytesLike>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>
+    ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "predictMyMultiSigAddress",
+    values: [
+      PromiseOrValue<BytesLike>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>
+    ]
+  ): string;
 
   decodeFunctionResult(
     functionFragment: "deployMyMultiSig",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "deployMyMultiSigDeterministic",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "predictMyMultiSigAddress",
     data: BytesLike
   ): Result;
 
@@ -80,6 +113,22 @@ export interface MyMultiSigDeployer extends BaseContract {
       threshold_: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
+
+    deployMyMultiSigDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    predictMyMultiSigAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: CallOverrides
+    ): Promise<[string] & { contractAddress: string }>;
   };
 
   deployMyMultiSig(
@@ -89,8 +138,40 @@ export interface MyMultiSigDeployer extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  deployMyMultiSigDeterministic(
+    salt_: PromiseOrValue<BytesLike>,
+    contractName_: PromiseOrValue<string>,
+    owners_: PromiseOrValue<string>[],
+    threshold_: PromiseOrValue<BigNumberish>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  predictMyMultiSigAddress(
+    salt_: PromiseOrValue<BytesLike>,
+    contractName_: PromiseOrValue<string>,
+    owners_: PromiseOrValue<string>[],
+    threshold_: PromiseOrValue<BigNumberish>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   callStatic: {
     deployMyMultiSig(
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    deployMyMultiSigDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    predictMyMultiSigAddress(
+      salt_: PromiseOrValue<BytesLike>,
       contractName_: PromiseOrValue<string>,
       owners_: PromiseOrValue<string>[],
       threshold_: PromiseOrValue<BigNumberish>,
@@ -107,6 +188,22 @@ export interface MyMultiSigDeployer extends BaseContract {
       threshold_: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
+
+    deployMyMultiSigDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    predictMyMultiSigAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
   };
 
   populateTransaction: {
@@ -115,6 +212,22 @@ export interface MyMultiSigDeployer extends BaseContract {
       owners_: PromiseOrValue<string>[],
       threshold_: PromiseOrValue<BigNumberish>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    deployMyMultiSigDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    predictMyMultiSigAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
   };
 }

--- a/types/MyMultiSigExtendedDeployer.ts
+++ b/types/MyMultiSigExtendedDeployer.ts
@@ -26,10 +26,15 @@ import type {
 export interface MyMultiSigExtendedDeployerInterface extends utils.Interface {
   functions: {
     "deployMyMultiSigExtended(string,address[],uint16,bool,address)": FunctionFragment;
+    "deployMyMultiSigExtendedDeterministic(bytes32,string,address[],uint16,bool,address)": FunctionFragment;
+    "predictMyMultiSigExtendedAddress(bytes32,string,address[],uint16,bool,address)": FunctionFragment;
   };
 
   getFunction(
-    nameOrSignatureOrTopic: "deployMyMultiSigExtended"
+    nameOrSignatureOrTopic:
+      | "deployMyMultiSigExtended"
+      | "deployMyMultiSigExtendedDeterministic"
+      | "predictMyMultiSigExtendedAddress"
   ): FunctionFragment;
 
   encodeFunctionData(
@@ -42,9 +47,39 @@ export interface MyMultiSigExtendedDeployerInterface extends utils.Interface {
       PromiseOrValue<string>
     ]
   ): string;
+  encodeFunctionData(
+    functionFragment: "deployMyMultiSigExtendedDeterministic",
+    values: [
+      PromiseOrValue<BytesLike>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>
+    ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "predictMyMultiSigExtendedAddress",
+    values: [
+      PromiseOrValue<BytesLike>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>
+    ]
+  ): string;
 
   decodeFunctionResult(
     functionFragment: "deployMyMultiSigExtended",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "deployMyMultiSigExtendedDeterministic",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "predictMyMultiSigExtendedAddress",
     data: BytesLike
   ): Result;
 
@@ -86,6 +121,26 @@ export interface MyMultiSigExtendedDeployer extends BaseContract {
       entryPoint_: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
+
+    deployMyMultiSigExtendedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    predictMyMultiSigExtendedAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<[string] & { contractAddress: string }>;
   };
 
   deployMyMultiSigExtended(
@@ -97,8 +152,48 @@ export interface MyMultiSigExtendedDeployer extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  deployMyMultiSigExtendedDeterministic(
+    salt_: PromiseOrValue<BytesLike>,
+    contractName_: PromiseOrValue<string>,
+    owners_: PromiseOrValue<string>[],
+    threshold_: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+    entryPoint_: PromiseOrValue<string>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  predictMyMultiSigExtendedAddress(
+    salt_: PromiseOrValue<BytesLike>,
+    contractName_: PromiseOrValue<string>,
+    owners_: PromiseOrValue<string>[],
+    threshold_: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+    entryPoint_: PromiseOrValue<string>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   callStatic: {
     deployMyMultiSigExtended(
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    deployMyMultiSigExtendedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    predictMyMultiSigExtendedAddress(
+      salt_: PromiseOrValue<BytesLike>,
       contractName_: PromiseOrValue<string>,
       owners_: PromiseOrValue<string>[],
       threshold_: PromiseOrValue<BigNumberish>,
@@ -119,6 +214,26 @@ export interface MyMultiSigExtendedDeployer extends BaseContract {
       entryPoint_: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
+
+    deployMyMultiSigExtendedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    predictMyMultiSigExtendedAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
   };
 
   populateTransaction: {
@@ -129,6 +244,26 @@ export interface MyMultiSigExtendedDeployer extends BaseContract {
       isOnlyOwnerRequest_: PromiseOrValue<boolean>,
       entryPoint_: PromiseOrValue<string>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    deployMyMultiSigExtendedDeterministic(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    predictMyMultiSigExtendedAddress(
+      salt_: PromiseOrValue<BytesLike>,
+      contractName_: PromiseOrValue<string>,
+      owners_: PromiseOrValue<string>[],
+      threshold_: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest_: PromiseOrValue<boolean>,
+      entryPoint_: PromiseOrValue<string>,
+      overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
   };
 }

--- a/types/MyMultiSigFactorable.ts
+++ b/types/MyMultiSigFactorable.ts
@@ -25,11 +25,15 @@ import type {
   TypedListener,
   OnEvent,
   PromiseOrValue,
-} from "../common";
+} from "../../common";
 
 export interface MyMultiSigFactorableInterface extends utils.Interface {
   functions: {
     "advancedCount()": FunctionFragment;
+    "computeSalt(address,bytes32)": FunctionFragment;
+    "createDeterministicMultiSig(string,address[],uint16,bytes32)": FunctionFragment;
+    "createDeterministicMyMultiSigAdvanced(string,address[],uint16,bool,address,bytes32)": FunctionFragment;
+    "createDeterministicMyMultiSigExtended(string,address[],uint16,bool,address,bytes32)": FunctionFragment;
     "createMultiSig(string,address[],uint16)": FunctionFragment;
     "createMyMultiSigAdvanced(string,address[],uint16,bool,address)": FunctionFragment;
     "createMyMultiSigExtended(string,address[],uint16,bool,address)": FunctionFragment;
@@ -47,6 +51,9 @@ export interface MyMultiSigFactorableInterface extends utils.Interface {
     "myMultiSigDeployer()": FunctionFragment;
     "myMultiSigExtendedDeployer()": FunctionFragment;
     "name()": FunctionFragment;
+    "predictMultiSigAddress(address,string,address[],uint16,bytes32)": FunctionFragment;
+    "predictMyMultiSigAdvancedAddress(address,string,address[],uint16,bool,address,bytes32)": FunctionFragment;
+    "predictMyMultiSigExtendedAddress(address,string,address[],uint16,bool,address,bytes32)": FunctionFragment;
     "simpleCount()": FunctionFragment;
     "version()": FunctionFragment;
   };
@@ -54,6 +61,10 @@ export interface MyMultiSigFactorableInterface extends utils.Interface {
   getFunction(
     nameOrSignatureOrTopic:
       | "advancedCount"
+      | "computeSalt"
+      | "createDeterministicMultiSig"
+      | "createDeterministicMyMultiSigAdvanced"
+      | "createDeterministicMyMultiSigExtended"
       | "createMultiSig"
       | "createMyMultiSigAdvanced"
       | "createMyMultiSigExtended"
@@ -71,6 +82,9 @@ export interface MyMultiSigFactorableInterface extends utils.Interface {
       | "myMultiSigDeployer"
       | "myMultiSigExtendedDeployer"
       | "name"
+      | "predictMultiSigAddress"
+      | "predictMyMultiSigAdvancedAddress"
+      | "predictMyMultiSigExtendedAddress"
       | "simpleCount"
       | "version"
   ): FunctionFragment;
@@ -78,6 +92,41 @@ export interface MyMultiSigFactorableInterface extends utils.Interface {
   encodeFunctionData(
     functionFragment: "advancedCount",
     values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "computeSalt",
+    values: [PromiseOrValue<string>, PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "createDeterministicMultiSig",
+    values: [
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<BytesLike>
+    ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "createDeterministicMyMultiSigAdvanced",
+    values: [
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>,
+      PromiseOrValue<BytesLike>
+    ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "createDeterministicMyMultiSigExtended",
+    values: [
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>,
+      PromiseOrValue<BytesLike>
+    ]
   ): string;
   encodeFunctionData(
     functionFragment: "createMultiSig",
@@ -161,6 +210,40 @@ export interface MyMultiSigFactorableInterface extends utils.Interface {
   ): string;
   encodeFunctionData(functionFragment: "name", values?: undefined): string;
   encodeFunctionData(
+    functionFragment: "predictMultiSigAddress",
+    values: [
+      PromiseOrValue<string>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<BytesLike>
+    ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "predictMyMultiSigAdvancedAddress",
+    values: [
+      PromiseOrValue<string>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>,
+      PromiseOrValue<BytesLike>
+    ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "predictMyMultiSigExtendedAddress",
+    values: [
+      PromiseOrValue<string>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>,
+      PromiseOrValue<BytesLike>
+    ]
+  ): string;
+  encodeFunctionData(
     functionFragment: "simpleCount",
     values?: undefined
   ): string;
@@ -168,6 +251,22 @@ export interface MyMultiSigFactorableInterface extends utils.Interface {
 
   decodeFunctionResult(
     functionFragment: "advancedCount",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "computeSalt",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "createDeterministicMultiSig",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "createDeterministicMyMultiSigAdvanced",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "createDeterministicMyMultiSigExtended",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -227,6 +326,18 @@ export interface MyMultiSigFactorableInterface extends utils.Interface {
   ): Result;
   decodeFunctionResult(functionFragment: "name", data: BytesLike): Result;
   decodeFunctionResult(
+    functionFragment: "predictMultiSigAddress",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "predictMyMultiSigAdvancedAddress",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "predictMyMultiSigExtendedAddress",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "simpleCount",
     data: BytesLike
   ): Result;
@@ -283,6 +394,40 @@ export interface MyMultiSigFactorable extends BaseContract {
 
   functions: {
     advancedCount(overrides?: CallOverrides): Promise<[BigNumber]>;
+
+    computeSalt(
+      creator: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[string]>;
+
+    createDeterministicMultiSig(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    createDeterministicMyMultiSigAdvanced(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    createDeterministicMyMultiSigExtended(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
 
     createMultiSig(
       contractName: PromiseOrValue<string>,
@@ -362,12 +507,77 @@ export interface MyMultiSigFactorable extends BaseContract {
 
     name(overrides?: CallOverrides): Promise<[string]>;
 
+    predictMultiSigAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[string] & { contractAddress: string }>;
+
+    predictMyMultiSigAdvancedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[string] & { contractAddress: string }>;
+
+    predictMyMultiSigExtendedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[string] & { contractAddress: string }>;
+
     simpleCount(overrides?: CallOverrides): Promise<[BigNumber]>;
 
     version(overrides?: CallOverrides): Promise<[string]>;
   };
 
   advancedCount(overrides?: CallOverrides): Promise<BigNumber>;
+
+  computeSalt(
+    creator: PromiseOrValue<string>,
+    salt: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
+  createDeterministicMultiSig(
+    contractName: PromiseOrValue<string>,
+    owners: PromiseOrValue<string>[],
+    threshold: PromiseOrValue<BigNumberish>,
+    salt: PromiseOrValue<BytesLike>,
+    overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  createDeterministicMyMultiSigAdvanced(
+    contractName: PromiseOrValue<string>,
+    owners: PromiseOrValue<string>[],
+    threshold: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest: PromiseOrValue<boolean>,
+    entryPoint: PromiseOrValue<string>,
+    salt: PromiseOrValue<BytesLike>,
+    overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  createDeterministicMyMultiSigExtended(
+    contractName: PromiseOrValue<string>,
+    owners: PromiseOrValue<string>[],
+    threshold: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest: PromiseOrValue<boolean>,
+    entryPoint: PromiseOrValue<string>,
+    salt: PromiseOrValue<BytesLike>,
+    overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
 
   createMultiSig(
     contractName: PromiseOrValue<string>,
@@ -447,12 +657,77 @@ export interface MyMultiSigFactorable extends BaseContract {
 
   name(overrides?: CallOverrides): Promise<string>;
 
+  predictMultiSigAddress(
+    creator: PromiseOrValue<string>,
+    contractName: PromiseOrValue<string>,
+    owners: PromiseOrValue<string>[],
+    threshold: PromiseOrValue<BigNumberish>,
+    salt: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
+  predictMyMultiSigAdvancedAddress(
+    creator: PromiseOrValue<string>,
+    contractName: PromiseOrValue<string>,
+    owners: PromiseOrValue<string>[],
+    threshold: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest: PromiseOrValue<boolean>,
+    entryPoint: PromiseOrValue<string>,
+    salt: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
+  predictMyMultiSigExtendedAddress(
+    creator: PromiseOrValue<string>,
+    contractName: PromiseOrValue<string>,
+    owners: PromiseOrValue<string>[],
+    threshold: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest: PromiseOrValue<boolean>,
+    entryPoint: PromiseOrValue<string>,
+    salt: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   simpleCount(overrides?: CallOverrides): Promise<BigNumber>;
 
   version(overrides?: CallOverrides): Promise<string>;
 
   callStatic: {
     advancedCount(overrides?: CallOverrides): Promise<BigNumber>;
+
+    computeSalt(
+      creator: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    createDeterministicMultiSig(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    createDeterministicMyMultiSigAdvanced(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    createDeterministicMyMultiSigExtended(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
 
     createMultiSig(
       contractName: PromiseOrValue<string>,
@@ -532,6 +807,37 @@ export interface MyMultiSigFactorable extends BaseContract {
 
     name(overrides?: CallOverrides): Promise<string>;
 
+    predictMultiSigAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    predictMyMultiSigAdvancedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    predictMyMultiSigExtendedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
     simpleCount(overrides?: CallOverrides): Promise<BigNumber>;
 
     version(overrides?: CallOverrides): Promise<string>;
@@ -558,6 +864,40 @@ export interface MyMultiSigFactorable extends BaseContract {
 
   estimateGas: {
     advancedCount(overrides?: CallOverrides): Promise<BigNumber>;
+
+    computeSalt(
+      creator: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    createDeterministicMultiSig(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    createDeterministicMyMultiSigAdvanced(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    createDeterministicMyMultiSigExtended(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
 
     createMultiSig(
       contractName: PromiseOrValue<string>,
@@ -637,6 +977,37 @@ export interface MyMultiSigFactorable extends BaseContract {
 
     name(overrides?: CallOverrides): Promise<BigNumber>;
 
+    predictMultiSigAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    predictMyMultiSigAdvancedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    predictMyMultiSigExtendedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     simpleCount(overrides?: CallOverrides): Promise<BigNumber>;
 
     version(overrides?: CallOverrides): Promise<BigNumber>;
@@ -644,6 +1015,40 @@ export interface MyMultiSigFactorable extends BaseContract {
 
   populateTransaction: {
     advancedCount(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
+    computeSalt(
+      creator: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
+    createDeterministicMultiSig(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    createDeterministicMyMultiSigAdvanced(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    createDeterministicMyMultiSigExtended(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
 
     createMultiSig(
       contractName: PromiseOrValue<string>,
@@ -728,6 +1133,37 @@ export interface MyMultiSigFactorable extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     name(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
+    predictMultiSigAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
+    predictMyMultiSigAdvancedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
+    predictMyMultiSigExtendedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
 
     simpleCount(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 

--- a/types/MyMultiSigFactory.ts
+++ b/types/MyMultiSigFactory.ts
@@ -31,6 +31,10 @@ import type {
 export interface MyMultiSigFactoryInterface extends utils.Interface {
   functions: {
     "advancedCount()": FunctionFragment;
+    "computeSalt(address,bytes32)": FunctionFragment;
+    "createDeterministicMultiSig(string,address[],uint16,bytes32)": FunctionFragment;
+    "createDeterministicMyMultiSigAdvanced(string,address[],uint16,bool,address,bytes32)": FunctionFragment;
+    "createDeterministicMyMultiSigExtended(string,address[],uint16,bool,address,bytes32)": FunctionFragment;
     "createMultiSig(string,address[],uint16)": FunctionFragment;
     "createMyMultiSigAdvanced(string,address[],uint16,bool,address)": FunctionFragment;
     "createMyMultiSigExtended(string,address[],uint16,bool,address)": FunctionFragment;
@@ -49,6 +53,9 @@ export interface MyMultiSigFactoryInterface extends utils.Interface {
     "myMultiSigDeployer()": FunctionFragment;
     "myMultiSigExtendedDeployer()": FunctionFragment;
     "name()": FunctionFragment;
+    "predictMultiSigAddress(address,string,address[],uint16,bytes32)": FunctionFragment;
+    "predictMyMultiSigAdvancedAddress(address,string,address[],uint16,bool,address,bytes32)": FunctionFragment;
+    "predictMyMultiSigExtendedAddress(address,string,address[],uint16,bool,address,bytes32)": FunctionFragment;
     "simpleCount()": FunctionFragment;
     "version()": FunctionFragment;
   };
@@ -56,6 +63,10 @@ export interface MyMultiSigFactoryInterface extends utils.Interface {
   getFunction(
     nameOrSignatureOrTopic:
       | "advancedCount"
+      | "computeSalt"
+      | "createDeterministicMultiSig"
+      | "createDeterministicMyMultiSigAdvanced"
+      | "createDeterministicMyMultiSigExtended"
       | "createMultiSig"
       | "createMyMultiSigAdvanced"
       | "createMyMultiSigExtended"
@@ -74,6 +85,9 @@ export interface MyMultiSigFactoryInterface extends utils.Interface {
       | "myMultiSigDeployer"
       | "myMultiSigExtendedDeployer"
       | "name"
+      | "predictMultiSigAddress"
+      | "predictMyMultiSigAdvancedAddress"
+      | "predictMyMultiSigExtendedAddress"
       | "simpleCount"
       | "version"
   ): FunctionFragment;
@@ -81,6 +95,41 @@ export interface MyMultiSigFactoryInterface extends utils.Interface {
   encodeFunctionData(
     functionFragment: "advancedCount",
     values?: undefined
+  ): string;
+  encodeFunctionData(
+    functionFragment: "computeSalt",
+    values: [PromiseOrValue<string>, PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "createDeterministicMultiSig",
+    values: [
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<BytesLike>
+    ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "createDeterministicMyMultiSigAdvanced",
+    values: [
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>,
+      PromiseOrValue<BytesLike>
+    ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "createDeterministicMyMultiSigExtended",
+    values: [
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>,
+      PromiseOrValue<BytesLike>
+    ]
   ): string;
   encodeFunctionData(
     functionFragment: "createMultiSig",
@@ -168,6 +217,40 @@ export interface MyMultiSigFactoryInterface extends utils.Interface {
   ): string;
   encodeFunctionData(functionFragment: "name", values?: undefined): string;
   encodeFunctionData(
+    functionFragment: "predictMultiSigAddress",
+    values: [
+      PromiseOrValue<string>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<BytesLike>
+    ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "predictMyMultiSigAdvancedAddress",
+    values: [
+      PromiseOrValue<string>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>,
+      PromiseOrValue<BytesLike>
+    ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "predictMyMultiSigExtendedAddress",
+    values: [
+      PromiseOrValue<string>,
+      PromiseOrValue<string>,
+      PromiseOrValue<string>[],
+      PromiseOrValue<BigNumberish>,
+      PromiseOrValue<boolean>,
+      PromiseOrValue<string>,
+      PromiseOrValue<BytesLike>
+    ]
+  ): string;
+  encodeFunctionData(
     functionFragment: "simpleCount",
     values?: undefined
   ): string;
@@ -175,6 +258,22 @@ export interface MyMultiSigFactoryInterface extends utils.Interface {
 
   decodeFunctionResult(
     functionFragment: "advancedCount",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "computeSalt",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "createDeterministicMultiSig",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "createDeterministicMyMultiSigAdvanced",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "createDeterministicMyMultiSigExtended",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -234,6 +333,18 @@ export interface MyMultiSigFactoryInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(functionFragment: "name", data: BytesLike): Result;
+  decodeFunctionResult(
+    functionFragment: "predictMultiSigAddress",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "predictMyMultiSigAdvancedAddress",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "predictMyMultiSigExtendedAddress",
+    data: BytesLike
+  ): Result;
   decodeFunctionResult(
     functionFragment: "simpleCount",
     data: BytesLike
@@ -300,6 +411,40 @@ export interface MyMultiSigFactory extends BaseContract {
 
   functions: {
     advancedCount(overrides?: CallOverrides): Promise<[BigNumber]>;
+
+    computeSalt(
+      creator: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[string]>;
+
+    createDeterministicMultiSig(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    createDeterministicMyMultiSigAdvanced(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    createDeterministicMyMultiSigExtended(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
 
     createMultiSig(
       contractName: PromiseOrValue<string>,
@@ -383,12 +528,77 @@ export interface MyMultiSigFactory extends BaseContract {
 
     name(overrides?: CallOverrides): Promise<[string]>;
 
+    predictMultiSigAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[string] & { contractAddress: string }>;
+
+    predictMyMultiSigAdvancedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[string] & { contractAddress: string }>;
+
+    predictMyMultiSigExtendedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<[string] & { contractAddress: string }>;
+
     simpleCount(overrides?: CallOverrides): Promise<[BigNumber]>;
 
     version(overrides?: CallOverrides): Promise<[string]>;
   };
 
   advancedCount(overrides?: CallOverrides): Promise<BigNumber>;
+
+  computeSalt(
+    creator: PromiseOrValue<string>,
+    salt: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
+  createDeterministicMultiSig(
+    contractName: PromiseOrValue<string>,
+    owners: PromiseOrValue<string>[],
+    threshold: PromiseOrValue<BigNumberish>,
+    salt: PromiseOrValue<BytesLike>,
+    overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  createDeterministicMyMultiSigAdvanced(
+    contractName: PromiseOrValue<string>,
+    owners: PromiseOrValue<string>[],
+    threshold: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest: PromiseOrValue<boolean>,
+    entryPoint: PromiseOrValue<string>,
+    salt: PromiseOrValue<BytesLike>,
+    overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  createDeterministicMyMultiSigExtended(
+    contractName: PromiseOrValue<string>,
+    owners: PromiseOrValue<string>[],
+    threshold: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest: PromiseOrValue<boolean>,
+    entryPoint: PromiseOrValue<string>,
+    salt: PromiseOrValue<BytesLike>,
+    overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
 
   createMultiSig(
     contractName: PromiseOrValue<string>,
@@ -472,12 +682,77 @@ export interface MyMultiSigFactory extends BaseContract {
 
   name(overrides?: CallOverrides): Promise<string>;
 
+  predictMultiSigAddress(
+    creator: PromiseOrValue<string>,
+    contractName: PromiseOrValue<string>,
+    owners: PromiseOrValue<string>[],
+    threshold: PromiseOrValue<BigNumberish>,
+    salt: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
+  predictMyMultiSigAdvancedAddress(
+    creator: PromiseOrValue<string>,
+    contractName: PromiseOrValue<string>,
+    owners: PromiseOrValue<string>[],
+    threshold: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest: PromiseOrValue<boolean>,
+    entryPoint: PromiseOrValue<string>,
+    salt: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
+  predictMyMultiSigExtendedAddress(
+    creator: PromiseOrValue<string>,
+    contractName: PromiseOrValue<string>,
+    owners: PromiseOrValue<string>[],
+    threshold: PromiseOrValue<BigNumberish>,
+    isOnlyOwnerRequest: PromiseOrValue<boolean>,
+    entryPoint: PromiseOrValue<string>,
+    salt: PromiseOrValue<BytesLike>,
+    overrides?: CallOverrides
+  ): Promise<string>;
+
   simpleCount(overrides?: CallOverrides): Promise<BigNumber>;
 
   version(overrides?: CallOverrides): Promise<string>;
 
   callStatic: {
     advancedCount(overrides?: CallOverrides): Promise<BigNumber>;
+
+    computeSalt(
+      creator: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    createDeterministicMultiSig(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    createDeterministicMyMultiSigAdvanced(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    createDeterministicMyMultiSigExtended(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
 
     createMultiSig(
       contractName: PromiseOrValue<string>,
@@ -559,6 +834,37 @@ export interface MyMultiSigFactory extends BaseContract {
 
     name(overrides?: CallOverrides): Promise<string>;
 
+    predictMultiSigAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    predictMyMultiSigAdvancedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
+    predictMyMultiSigExtendedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<string>;
+
     simpleCount(overrides?: CallOverrides): Promise<BigNumber>;
 
     version(overrides?: CallOverrides): Promise<string>;
@@ -588,6 +894,40 @@ export interface MyMultiSigFactory extends BaseContract {
 
   estimateGas: {
     advancedCount(overrides?: CallOverrides): Promise<BigNumber>;
+
+    computeSalt(
+      creator: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    createDeterministicMultiSig(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    createDeterministicMyMultiSigAdvanced(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    createDeterministicMyMultiSigExtended(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
 
     createMultiSig(
       contractName: PromiseOrValue<string>,
@@ -671,6 +1011,37 @@ export interface MyMultiSigFactory extends BaseContract {
 
     name(overrides?: CallOverrides): Promise<BigNumber>;
 
+    predictMultiSigAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    predictMyMultiSigAdvancedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
+    predictMyMultiSigExtendedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<BigNumber>;
+
     simpleCount(overrides?: CallOverrides): Promise<BigNumber>;
 
     version(overrides?: CallOverrides): Promise<BigNumber>;
@@ -678,6 +1049,40 @@ export interface MyMultiSigFactory extends BaseContract {
 
   populateTransaction: {
     advancedCount(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
+    computeSalt(
+      creator: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
+    createDeterministicMultiSig(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    createDeterministicMyMultiSigAdvanced(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    createDeterministicMyMultiSigExtended(
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: PayableOverrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
 
     createMultiSig(
       contractName: PromiseOrValue<string>,
@@ -766,6 +1171,37 @@ export interface MyMultiSigFactory extends BaseContract {
     ): Promise<PopulatedTransaction>;
 
     name(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
+    predictMultiSigAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
+    predictMyMultiSigAdvancedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
+
+    predictMyMultiSigExtendedAddress(
+      creator: PromiseOrValue<string>,
+      contractName: PromiseOrValue<string>,
+      owners: PromiseOrValue<string>[],
+      threshold: PromiseOrValue<BigNumberish>,
+      isOnlyOwnerRequest: PromiseOrValue<boolean>,
+      entryPoint: PromiseOrValue<string>,
+      salt: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<PopulatedTransaction>;
 
     simpleCount(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 


### PR DESCRIPTION
## Why

The v0.5.0 release commit (`185c245`) advertised **"CREATE2 deterministic wallets"** as headline feature #1, but the follow-up reshape (`7b94312`) dropped the V2_5 class that carried it and deferred CREATE2 — the deployers still did plain `new MyMultiSig(...)` with no salt. This PR closes that gap and delivers the feature.

## Design

Salted creation (`new Wallet{salt: ...}(...)`) instead of the originally sketched `Clones.cloneDeterministic`: full creation bytecode with ordinary constructors, so **no `Initializable` conversion, no storage-layout change, no proxies** — deterministic wallets are byte-identical to classic ones. The blocker that forced the deferral simply doesn't apply to this approach.

| Classic (CREATE) | Deterministic (CREATE2) | Predict without deploying |
| --- | --- | --- |
| `createMultiSig(...)` | `createDeterministicMultiSig(..., salt)` | `predictMultiSigAddress(creator, ..., salt)` |
| `createMyMultiSigExtended(...)` | `createDeterministicMyMultiSigExtended(..., salt)` | `predictMyMultiSigExtendedAddress(creator, ..., salt)` |
| `createMyMultiSigAdvanced(...)` | `createDeterministicMyMultiSigAdvanced(..., salt)` | `predictMyMultiSigAdvancedAddress(creator, ..., salt)` |

Salt derivation has two layers:

- **Factory**: `computeSalt(msg.sender, salt)` — two creators using the same salt never race for one address.
- **Deployer**: namespaces the incoming salt by its direct caller — a third party calling a deployer directly can never squat an address a factory-mediated deploy resolves to, and Advanced deploys (routed Advanced → Extended deployer) never collide with Extended deploys sharing a salt and arguments.

Same creator + salt + constructor arguments on any chain where the factory and deployers sit at the same addresses (see `FACTORY_SALT` / `CANONICAL_CREATE2_DEPLOYER` in `constants/extended.ts`) yield the **same wallet address on every chain**. Salt reuse with identical arguments reverts.

The proxied factory gains **functions only** — no state variables touched.

## Also in this PR

- `scripts/buildTypes.ts` only scanned the top level of `typechain-types/contracts/`, so every `yarn build` deleted the committed interface/abstract types instead of regenerating them; it now scans `interfaces/` and `abstracts/` too, and the committed `types/` are regenerated for the new ABI.
- README section 3 ("deferred to a follow-up") replaced with the shipped design; `constants/extended.ts` comments updated to the live cross-chain story.

## Testing

- Foundry: 156 passed (8 new in `contracts/test/MyMultiSigFactory.create2.t.sol`) — `forge test`
- Hardhat: 306 passing (5 new in `test/MyMultiSigFactoryCreate2.test.ts`) — `npx hardhat test`
- Coverage: predict==deploy for all three types, bookkeeping/creation-type recording, salt-reuse revert, per-creator address separation, Advanced/Extended non-collision, deployer-squatting resistance, prediction purity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)