### PR TITLE
fix: complete the timelock sensitive-selector set

### DIFF
--- a/contracts/MyMultiSigExtended.sol
+++ b/contracts/MyMultiSigExtended.sol
@@ -353,8 +353,11 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   }
 
   /// @dev The built-in default sensitive-selector set, kept in code so the
-  ///      constructor doesn't pay 10 cold SSTOREs per deployment. Every
-  ///      privileged admin selector of the wallet family is listed;
+  ///      constructor doesn't pay one cold SSTORE per selector per
+  ///      deployment. Every privileged admin selector of the wallet family
+  ///      is listed — including the setters that weaken a protection
+  ///      (guard, allowlist, allowance, and the sensitive-set itself), so
+  ///      the timelock cannot be sidestepped by reconfiguring it;
   ///      `setSensitiveSelector` overrides win over this default.
   function _isDefaultSensitiveSelector(bytes4 sel) internal pure virtual returns (bool) {
     return
@@ -367,7 +370,13 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
       sel == bytes4(keccak256('markNonceAsUsed(uint256)')) ||
       sel == bytes4(keccak256('enableModule(address)')) ||
       sel == bytes4(keccak256('disableModule(address,address)')) ||
-      sel == bytes4(keccak256('setTimelockDelay(uint256)'));
+      sel == bytes4(keccak256('setTimelockDelay(uint256)')) ||
+      sel == bytes4(keccak256('setSensitiveValueThreshold(uint256)')) ||
+      sel == bytes4(keccak256('setSensitiveSelector(bytes4,bool)')) ||
+      sel == bytes4(keccak256('setGuard(address)')) ||
+      sel == bytes4(keccak256('setAllowedTarget(address,bool)')) ||
+      sel == bytes4(keccak256('disableAllowlist()')) ||
+      sel == bytes4(keccak256('setDailySpendingLimit(address,uint256)'));
   }
 
   /// @notice Returns the unix timestamp a scheduled tx is ready to execute at.
@@ -387,7 +396,7 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   // ---------------------------------------------------------------------------
 
   /// @notice Sets the per-call timelock delay. `setTimelockDelay` itself is
-  ///         a sensitive selector (registered in the constructor), so
+  ///         a sensitive selector (in the built-in default set), so
   ///         reducing the delay also goes through the slow path.
   function setTimelockDelay(uint256 delay) public virtual onlyThis {
     if (delay > type(uint88).max) revert DelayTooLong();

--- a/test/shared/tests.ts
+++ b/test/shared/tests.ts
@@ -2533,6 +2533,82 @@ export async function MyMultiSigAdvancedTests(deploymentType = DeploymentType.Si
             .executeScheduled(contract.address, Helper.ZERO, data, Helper.DEFAULT_GAS, nonce, 0, signatures),
         ).to.be.revertedWithCustomError(contract, 'NotScheduled')
       })
+
+      it('every protection-weakening setter is in the default sensitive set', async function () {
+        const sensitiveFragments = [
+          'setGuard(address)',
+          'setAllowedTarget(address,bool)',
+          'disableAllowlist()',
+          'setDailySpendingLimit(address,uint256)',
+          'setSensitiveSelector(bytes4,bool)',
+          'setSensitiveValueThreshold(uint256)',
+        ]
+        for (const fragment of sensitiveFragments) {
+          const selector = ethers.utils.id(fragment).slice(0, 10)
+          expect(await contract.isSensitiveSelector(selector), fragment).to.be.true
+        }
+      })
+
+      it('protection setters revert with SensitiveCallRequiresDelay once the timelock is on', async function () {
+        await Helper.setTimelockDelay(contract, owner01, [owner01, owner02], 60)
+        const sensitiveCalls: `0x${string}`[] = [
+          contract.interface.encodeFunctionData('setGuard(address)', [user03.address]),
+          contract.interface.encodeFunctionData('setAllowedTarget(address,bool)', [user01.address, true]),
+          contract.interface.encodeFunctionData('disableAllowlist()', []),
+          contract.interface.encodeFunctionData('setDailySpendingLimit(address,uint256)', [
+            owner01.address,
+            ethers.utils.parseEther('1'),
+          ]),
+          contract.interface.encodeFunctionData('setSensitiveSelector(bytes4,bool)', ['0x12345678', false]),
+          contract.interface.encodeFunctionData('setSensitiveValueThreshold(uint256)', [ethers.utils.parseEther('1')]),
+        ]
+        for (const data of sensitiveCalls) {
+          await Helper.execTransaction(
+            contract,
+            owner01,
+            [owner01, owner02],
+            contract.address,
+            Helper.ZERO,
+            data,
+            Helper.DEFAULT_GAS,
+            'SensitiveCallRequiresDelay',
+          )
+        }
+        // None of the protections were configured through the fast path.
+        expect(await contract.guard()).to.be.equal(ethers.constants.AddressZero)
+        expect(await contract.allowedTargetsEnabled()).to.be.false
+        expect(await contract.dailySpendingLimit(owner01.address)).to.be.equal(0)
+        expect(await contract.sensitiveValueThreshold()).to.be.equal(0)
+      })
+
+      it('protection setters remain reachable through schedule + executeScheduled', async function () {
+        await Helper.setTimelockDelay(contract, owner01, [owner01, owner02], 60)
+        const Guard = await ethers.getContractFactory('MockGuard')
+        const guard = await Guard.deploy()
+        await guard.deployed()
+        const data = contract.interface.encodeFunctionData('setGuard(address)', [guard.address])
+        const nonce = await contract.nonce()
+        const signatures = await Helper.prepareSignatures(
+          contract,
+          [owner01, owner02],
+          contract.address,
+          Helper.ZERO,
+          data,
+          Helper.DEFAULT_GAS,
+          nonce,
+          0,
+        )
+        const schedTx = await contract
+          .connect(owner01)
+          .scheduleTransaction(contract.address, Helper.ZERO, data, Helper.DEFAULT_GAS, nonce, 0, signatures)
+        await schedTx.wait()
+        await Helper.advanceTime(61)
+        const execTx = await contract
+          .connect(owner01)
+          .executeScheduled(contract.address, Helper.ZERO, data, Helper.DEFAULT_GAS, nonce, 0, signatures)
+        await execTx.wait()
+        expect(await contract.guard()).to.be.equal(guard.address)
+      })
     })
 
     // -- Feature 2: Guard + allowlist --------------------------------------


### PR DESCRIPTION
## Problem

The built-in default sensitive-selector set (`_isDefaultSensitiveSelector`) covered owner / threshold / module / timelock-delay administration, but **not** the setters that configure the other protections. With a timelock active, a compromised signing threshold could still instantly:

- `setGuard` — swap or remove the transaction guard
- `setAllowedTarget` — add an attacker target to the allowlist
- `setDailySpendingLimit` — grant a single-signer spending allowance
- `setSensitiveSelector` — prune the sensitive set itself
- `setSensitiveValueThreshold` — lift the value cap

defeating the timelock's purpose as a reaction window.

## Fix

All of the above are now in the default sensitive set, plus **`disableAllowlist`** — not in the original finding, but leaving it instant would let an attacker bypass the timelocked `setAllowedTarget` by simply switching allowlist enforcement off.

Once `_timelockDelay > 0`, these calls must go through `scheduleTransaction` → delay → `executeScheduled`. Owners can still prune any selector via `setSensitiveSelector(sel, false)` — itself through the slow path.

The set is an `internal pure` function, so there is no ABI or storage-layout change (wallets are deployed fresh via `new`, not proxied).

## Tests

- New: the six setters are reported sensitive by default, revert with `SensitiveCallRequiresDelay` on the fast path when a timelock is active, and remain reachable through schedule + execute.
- `npx hardhat test`: 312 passing; `forge test`: 156 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)