### PR TITLE
fix: skip stale approvals from removed owners in vote counting

### DIFF
--- a/contracts/MyMultiSig.sol
+++ b/contracts/MyMultiSig.sol
@@ -591,8 +591,9 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   ///         the public EIP-1271 `isValidSignature(bytes32,bytes)` and the
   ///         6-arg view `isValidSignature(address,...,bytes)`.
   /// @dev    On-chain `approveHash` approvals count as votes for the matching
-  ///         tx hash without any signature payload. An approved owner that was
-  ///         later removed from the wallet fails the owner check.
+  ///         tx hash without any signature payload. An approval from an
+  ///         address that is no longer an owner is skipped — it neither
+  ///         counts toward the threshold nor blocks the remaining votes.
   function _checkSignatures(
     bytes32 txHash,
     uint256 txnNonce,
@@ -604,8 +605,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     uint256 counted;
     for (uint256 i; i < approvedLength; ) {
       unchecked {
-        if (!_owners[approved[i]]) return false;
-        ++counted;
+        if (_owners[approved[i]]) ++counted;
         ++i;
       }
     }
@@ -732,17 +732,16 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   ) internal virtual returns (bool valid) {
     uint16 threshold_ = _threshold;
     // On-chain approvals count as votes and consume their (nonce, owner)
-    // slot. An approved owner that was later removed from the wallet fails
-    // the check and aborts the whole validation — no partial application.
+    // slot. An approval from an address that is no longer an owner, or whose
+    // (nonce, owner) slot is already consumed, is skipped — it neither counts
+    // toward the threshold nor blocks the remaining votes.
     address[] storage approved = _approvedOwners[txHash];
     uint256 approvedLength = approved.length;
     uint256 counted;
     for (uint256 i; i < approvedLength; ) {
       unchecked {
         address approvedOwner = approved[i];
-        if (!_owners[approvedOwner]) return false;
-        if (!_recordVote(txHash, txnNonce, approvedOwner)) return false;
-        ++counted;
+        if (_owners[approvedOwner] && _recordVote(txHash, txnNonce, approvedOwner)) ++counted;
         ++i;
       }
     }

--- a/contracts/test/shared/tests.t.sol
+++ b/contracts/test/shared/tests.t.sol
@@ -435,6 +435,77 @@ abstract contract TestBasic is Helper {
   }
 
   // ---------------------------------------------------------------------
+  // stale approvals (approveHash then owner removal)
+  // ---------------------------------------------------------------------
+
+  /// @dev The digest the exec path validates: the base wallet's 6-field
+  ///      `generateHash`, or the extended wallet's operation-bound
+  ///      `generateHashOp` with `operation = 0`.
+  function build_execHash(bytes memory data, uint256 gas, uint96 nonce) internal view returns (bytes32) {
+    if (isExtended(myMultiSig)) {
+      return
+        MyMultiSigExtended(payable(address(myMultiSig))).generateHashOp(address(myMultiSig), 0, data, gas, nonce, 0, 0);
+    }
+    return myMultiSig.generateHash(address(myMultiSig), 0, data, gas, nonce, 0);
+  }
+
+  function testMyMultiSig_staleApprovalFromRemovedOwnerIsSkipped() public {
+    // OWNERS[0] pre-approves the addOwner(NOT_OWNERS[1]) hash bound to
+    // nonce 1, then is replaced at nonce 0. The stale approval stays in
+    // getApprovedOwners but must be skipped by the vote count: two
+    // signatures from current owners reach the threshold on their own.
+    address to = address(myMultiSig);
+    bytes memory data = build_addOwner(NOT_OWNERS[1]);
+    uint256 gas = DEFAULT_GAS;
+    bytes32 hash = build_execHash(data, gas, 1);
+
+    vm.prank(OWNERS[0]);
+    myMultiSig.approveHash(hash);
+
+    help_replaceOwner(OWNERS[1], myMultiSig, OWNERS_PK, OWNERS[0], NOT_OWNERS[0]);
+    assertFalse(myMultiSig.isOwner(OWNERS[0]));
+    assertEq(myMultiSig.getApprovedOwners(hash).length, 1);
+
+    uint256[] memory freshPks = new uint256[](2);
+    freshPks[0] = OWNERS_PK[1];
+    freshPks[1] = OWNERS_PK[2];
+    bytes memory signatures = build_signatures(myMultiSig, freshPks, to, 0, data, gas);
+    help_execTransaction(myMultiSig, OWNERS[1], to, 0, data, gas, signatures);
+    assertTrue(myMultiSig.isOwner(NOT_OWNERS[1]));
+  }
+
+  function testMyMultiSig_staleApprovalFromRemovedOwnerDoesNotCount() public {
+    // Same setup, but the executor leans on the stale approval plus a single
+    // fresh signature: 1 valid vote < threshold (2), so execution must
+    // revert with InvalidSignatures.
+    address to = address(myMultiSig);
+    bytes memory data = build_addOwner(NOT_OWNERS[1]);
+    uint256 gas = DEFAULT_GAS;
+    bytes32 hash = build_execHash(data, gas, 1);
+
+    vm.prank(OWNERS[0]);
+    myMultiSig.approveHash(hash);
+
+    help_replaceOwner(OWNERS[1], myMultiSig, OWNERS_PK, OWNERS[0], NOT_OWNERS[0]);
+
+    uint256[] memory freshPks = new uint256[](1);
+    freshPks[0] = OWNERS_PK[1];
+    bytes memory signatures = build_signatures(myMultiSig, freshPks, to, 0, data, gas);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[1],
+      to,
+      0,
+      data,
+      gas,
+      signatures,
+      myMultiSig.nonce(),
+      Errors.RevertStatus.InvalidSignatures
+    );
+    assertFalse(myMultiSig.isOwner(NOT_OWNERS[1]));
+  }
+
+  // ---------------------------------------------------------------------
   // multiRequestStrict (atomic batch)
   // ---------------------------------------------------------------------
 

--- a/test/shared/tests.ts
+++ b/test/shared/tests.ts
@@ -795,7 +795,7 @@ export async function MyMultiSigStandardTests(deploymentType = DeploymentType.Si
         expect(await contract.getApprovedOwners(hashN1)).to.have.lengthOf(1)
       })
 
-      it('Approving with an owner who was later removed makes isValidSignature false', async function () {
+      it('An owner who was removed can no longer call approveHash', async function () {
         const data = contract.interface.encodeFunctionData('replaceOwner(address,address)', [
           owner01.address,
           user01.address,
@@ -817,6 +817,119 @@ export async function MyMultiSigStandardTests(deploymentType = DeploymentType.Si
           ['OwnerRemoved', 'OwnerAdded'],
         )
         await Helper.approveHash(contract, owner01, hash, Helper.errors.NOT_OWNER)
+      })
+
+      it('A stale approval from a removed owner is skipped and current owners can still execute', async function () {
+        // owner01 pre-approves the addOwner(user02) hash bound to nonce 1,
+        // then is replaced at nonce 0. The stale approval stays recorded in
+        // getApprovedOwners but must not count nor block: two signatures from
+        // current owners reach the threshold on their own.
+        const addUser02 = contract.interface.encodeFunctionData('addOwner(address)', [user02.address])
+        const hash = await contract.generateHash(
+          contract.address,
+          Helper.ZERO,
+          addUser02,
+          Helper.DEFAULT_GAS,
+          ethers.BigNumber.from(1),
+          0,
+        )
+        await Helper.approveHash(contract, owner01, hash)
+
+        const replaceData = contract.interface.encodeFunctionData('replaceOwner(address,address)', [
+          owner01.address,
+          user01.address,
+        ])
+        await Helper.execTransaction(
+          contract,
+          owner01,
+          [owner02, owner03],
+          contract.address,
+          Helper.ZERO,
+          replaceData,
+          Helper.DEFAULT_GAS,
+          undefined,
+          ['OwnerRemoved', 'OwnerAdded'],
+        )
+        expect(await contract.isOwner(owner01.address)).to.be.false
+        expect(await contract.getApprovedOwners(hash)).to.include(owner01.address)
+
+        const signatures = await Helper.prepareSignatures(
+          contract,
+          [owner02, owner03],
+          contract.address,
+          Helper.ZERO,
+          addUser02,
+          Helper.DEFAULT_GAS,
+          ethers.BigNumber.from(1),
+        )
+        await Helper.execTransaction(
+          contract,
+          owner02,
+          [owner02, owner03],
+          contract.address,
+          Helper.ZERO,
+          addUser02,
+          Helper.DEFAULT_GAS,
+          undefined,
+          ['OwnerAdded'],
+          signatures,
+        )
+        expect(await contract.isOwner(user02.address)).to.be.true
+      })
+
+      it('A stale approval from a removed owner does not count toward the threshold', async function () {
+        // Same setup as above, but the executor relies on the stale approval
+        // plus a single fresh signature: 1 valid vote < threshold (2), so the
+        // execution must revert with InvalidSignatures.
+        const addUser02 = contract.interface.encodeFunctionData('addOwner(address)', [user02.address])
+        const hash = await contract.generateHash(
+          contract.address,
+          Helper.ZERO,
+          addUser02,
+          Helper.DEFAULT_GAS,
+          ethers.BigNumber.from(1),
+          0,
+        )
+        await Helper.approveHash(contract, owner01, hash)
+
+        const replaceData = contract.interface.encodeFunctionData('replaceOwner(address,address)', [
+          owner01.address,
+          user01.address,
+        ])
+        await Helper.execTransaction(
+          contract,
+          owner01,
+          [owner02, owner03],
+          contract.address,
+          Helper.ZERO,
+          replaceData,
+          Helper.DEFAULT_GAS,
+          undefined,
+          ['OwnerRemoved', 'OwnerAdded'],
+        )
+
+        const signatures = await Helper.prepareSignatures(
+          contract,
+          [owner02],
+          contract.address,
+          Helper.ZERO,
+          addUser02,
+          Helper.DEFAULT_GAS,
+          ethers.BigNumber.from(1),
+        )
+        await Helper.execTransaction(
+          contract,
+          owner02,
+          [owner02],
+          contract.address,
+          Helper.ZERO,
+          addUser02,
+          Helper.DEFAULT_GAS,
+          Helper.errors.INVALID_SIGNATURES,
+          undefined,
+          signatures,
+        )
+        expect(await contract.isOwner(user02.address)).to.be.false
       })
     })
 


### PR DESCRIPTION
## Problem

If an owner calls `approveHash` and is later removed or replaced, both vote-counting cores — the view `_checkSignatures` and the mutating `_validateSignatureForHash` — returned `false` for the whole validation as soon as they hit the stale approval, instead of just not counting it.

This is an easy grief vector: approve a pending hash, get removed (or get yourself replaced), and the pending transaction can no longer execute until the nonce is bumped, wiping every other owner's collected votes along the way.

## Fix

A recorded approval from an address that is no longer an owner (or whose `(nonce, owner)` slot is already consumed) is now **skipped**: it neither counts toward the threshold nor blocks the remaining votes. This matches how the signature-vote loop already treats invalid entries, and mirrors Safe's semantics where a stale `approvedHashes` entry is simply inert.

No ABI change — function bodies only, so no type regeneration needed.

## Tests

- Foundry (`contracts/test/shared/tests.t.sol`, runs on base, factory and extended variants): stale approval is skipped and fresh current-owner signatures still execute; stale approval alone + one signature stays below threshold (`InvalidSignatures`).
- Hardhat (`test/shared/tests.ts`): same two scenarios, plus a retitle of the adjacent test to match what it actually asserts.
- Verified the new tests fail on the previous contract code and pass with the fix.
- Full suites green: `forge test` (162) and `npx hardhat test` (316).

🤖 Generated with [Claude Code](https://claude.com/claude-code)