### PR TITLE
fix(wallet): close remaining v0.5 gaps — post-exec guard, getOwners, must-succeed, batch & schedule hardening

### DIFF
--- a/contracts/MyMultiSig.sol
+++ b/contracts/MyMultiSig.sol
@@ -5,16 +5,24 @@ import '@openzeppelin/contracts/security/ReentrancyGuard.sol';
 import '@openzeppelin/contracts/utils/cryptography/ECDSA.sol';
 import '@openzeppelin/contracts/utils/cryptography/EIP712.sol';
 import '@openzeppelin/contracts/interfaces/IERC1271.sol';
+import '@openzeppelin/contracts/token/ERC721/IERC721Receiver.sol';
 import '@openzeppelin/contracts/token/ERC721/utils/ERC721Holder.sol';
 import '@openzeppelin/contracts/token/ERC1155/utils/ERC1155Holder.sol';
 
-contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
+contract MyMultiSig is ReentrancyGuard, EIP712, IERC1271, ERC721Holder, ERC1155Holder {
   string private _name;
   uint96 private _txnNonce;
   uint16 private _threshold;
   uint16 private _ownerCount;
 
-  mapping(address => bool) private _owners;
+  /// @notice Owners as a sentinel-headed singly-linked list (the same
+  ///         pattern as the modules list in `MyMultiSigExtended`):
+  ///         `_ownersNext[_SENTINEL_OWNER]` is the most recently added owner,
+  ///         each owner points to the next one, and the last owner points
+  ///         back to `_SENTINEL_OWNER`. An address is an owner iff its entry
+  ///         is non-zero (see `isOwner`), and the list makes the full owner
+  ///         set enumerable on-chain via `getOwners`.
+  mapping(address => address) private _ownersNext;
   mapping(uint256 => bool) private _ownerNonceSigned;
   /// @notice Per-hash set of owners who have pre-approved the transaction
   ///         via `approveHash`. Keyed by the 32-byte EIP-712 transaction hash.
@@ -29,6 +37,16 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   ///         cannot be replayed against another wallet. Read by the
   ///         EIP-1271 `isValidSignature(bytes32,bytes)` empty-signature path.
   mapping(bytes32 => bool) private _signedMessages;
+
+  /// @notice When true, an inner call that fails inside `execTransaction`
+  ///         reverts the whole transaction (`TxSuccessRequired`) instead of
+  ///         emitting `TxFailure` — so the nonce is not consumed and the
+  ///         collected signatures stay usable for a retry.
+  bool private _requireTxSuccess;
+
+  /// @notice Sentinel head/tail of the owners linked list. Never a valid
+  ///         owner itself; `_addOwner` rejects it like the zero address.
+  address private constant _SENTINEL_OWNER = address(0x1);
 
   /// @notice EIP-712 typehash for the per-transaction payload. Includes a
   ///         `uint256 validUntil` deadline so signatures carry an explicit
@@ -113,6 +131,9 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   /// @notice Emitted when a previously-signed message is withdrawn via
   ///         `unsignMessage`, so EIP-1271 verifiers stop accepting it.
   event MessageUnsigned(bytes32 indexed msgHash);
+  /// @notice Emitted when `setRequireTxSuccess` toggles the must-succeed
+  ///         execution mode (see `requireTxSuccess`).
+  event RequireTxSuccessSet(bool required);
 
   error OnlyThisContract();
   error TooManyOwners();
@@ -136,6 +157,17 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   ///         outer `execTransaction` reverts — no side effects from the
   ///         batch persist.
   error BatchCallFailed(uint256 index, bytes reason);
+  /// @notice `multiRequest` / `multiRequestStrict` received arrays of
+  ///         different lengths — every batch array must have one entry per
+  ///         inner call.
+  error ArrayLengthMismatch();
+  /// @notice The inner call failed while `requireTxSuccess()` is enabled.
+  ///         The whole `execTransaction` reverts, so the nonce is not
+  ///         consumed and the collected signatures stay usable.
+  error TxSuccessRequired();
+  /// @notice `removeOwner` was called for an address that is not a current
+  ///         owner.
+  error OwnerToRemoveMustBeOwner();
   error NotOwner();
   error NotEnoughGas();
   error OwnerAlreadyExists();
@@ -153,6 +185,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
 
   constructor(string memory name_, address[] memory owners_, uint16 threshold_) EIP712(name_, version()) {
     _name = name_;
+    _ownersNext[_SENTINEL_OWNER] = _SENTINEL_OWNER;
     uint256 length = owners_.length;
     if (length > 2 ** 16 - 1) revert TooManyOwners();
     for (uint256 i = 0; i < length; ) {
@@ -200,7 +233,50 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   /// @param owner The address to be checked.
   /// @return True if the address is the owner, false otherwise.
   function isOwner(address owner) public view virtual returns (bool) {
-    return _owners[owner];
+    return owner != _SENTINEL_OWNER && _ownersNext[owner] != address(0);
+  }
+
+  /// @notice Returns every current owner by walking the linked list. Order
+  ///         is most-recently-added first (owners are inserted at the head,
+  ///         like the modules list in `MyMultiSigExtended`); `replaceOwner`
+  ///         keeps the replaced owner's position.
+  /// @return owners The list of current owner addresses.
+  function getOwners() public view virtual returns (address[] memory owners) {
+    owners = new address[](_ownerCount);
+    address cursor = _ownersNext[_SENTINEL_OWNER];
+    for (uint256 i; cursor != _SENTINEL_OWNER; ) {
+      owners[i] = cursor;
+      cursor = _ownersNext[cursor];
+      unchecked {
+        ++i;
+      }
+    }
+  }
+
+  /// @notice Whether must-succeed execution mode is on. When enabled, a
+  ///         failed inner call reverts the whole `execTransaction` with
+  ///         `TxSuccessRequired` instead of emitting `TxFailure` and
+  ///         consuming the nonce.
+  function requireTxSuccess() public view virtual returns (bool) {
+    return _requireTxSuccess;
+  }
+
+  /// @notice Toggles must-succeed execution mode (see `requireTxSuccess`).
+  /// @param required True to revert `execTransaction` on inner-call failure.
+  /// @dev This function can only be called inside a multisig transaction.
+  function setRequireTxSuccess(bool required) public virtual onlyThis {
+    _requireTxSuccess = required;
+    emit RequireTxSuccessSet(required);
+  }
+
+  /// @notice ERC-165 introspection. Advertises EIP-1271
+  ///         (`isValidSignature(bytes32,bytes)`), the ERC-721 and ERC-1155
+  ///         receiver hooks, and ERC-165 itself.
+  function supportsInterface(bytes4 interfaceId) public view virtual override returns (bool) {
+    return
+      interfaceId == type(IERC1271).interfaceId ||
+      interfaceId == type(IERC721Receiver).interfaceId ||
+      super.supportsInterface(interfaceId);
   }
 
   /// @notice Returns the owners who have pre-approved the given hash via
@@ -236,7 +312,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   ///      Reverts with `NotOwner` if `msg.sender` is not a current owner.
   /// @param hash The EIP-712 transaction hash to approve.
   function approveHash(bytes32 hash) public virtual {
-    if (!_owners[msg.sender]) revert NotOwner();
+    if (!isOwner(msg.sender)) revert NotOwner();
     if (_approvedHashes[hash][msg.sender]) return;
     _approvedHashes[hash][msg.sender] = true;
     _approvedOwners[hash].push(msg.sender);
@@ -262,7 +338,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   ///      `MyMultiSigExtended`).
   /// @param hash The EIP-712 transaction hash to revoke.
   function revokeApproval(bytes32 hash) public virtual {
-    if (!_owners[msg.sender]) revert NotOwner();
+    if (!isOwner(msg.sender)) revert NotOwner();
     if (!_approvedHashes[hash][msg.sender]) revert NotApproved();
     _approvedHashes[hash][msg.sender] = false;
     _removeApprovedOwner(hash, msg.sender);
@@ -419,6 +495,8 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
       // caller can decode the actual reason — emitting TxFailure here would
       // hide the structured error inside an opaque bytes blob.
       _revertWith(returnData);
+    } else if (_requireTxSuccess) {
+      revert TxSuccessRequired();
     } else {
       emit TxFailure(msg.sender, to, value, data, txnGas, txnNonce, returnData);
     }
@@ -451,6 +529,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     uint256[] memory txGas
   ) public payable virtual onlyThis returns (bool[] memory successes, bytes[] memory returnData) {
     uint256 qty = to.length;
+    if (value.length != qty || data.length != qty || txGas.length != qty) revert ArrayLengthMismatch();
     successes = new bool[](qty);
     returnData = new bytes[](qty);
     for (uint256 i; i < qty; ) {
@@ -491,6 +570,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     uint256[] memory txGas
   ) public payable virtual onlyThis {
     uint256 qty = to.length;
+    if (value.length != qty || data.length != qty || txGas.length != qty) revert ArrayLengthMismatch();
     for (uint256 i; i < qty; ) {
       _beforeInnerCall(to[i], value[i], data[i]);
       (bool ok, bytes memory returnData) = _rawCall(txGas[i], to[i], value[i], data[i]);
@@ -624,7 +704,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     uint256 counted;
     for (uint256 i; i < approvedLength; ) {
       unchecked {
-        if (_owners[approved[i]]) ++counted;
+        if (isOwner(approved[i])) ++counted;
         ++i;
       }
     }
@@ -654,7 +734,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   ///         - 65-byte ECDSA `r || s || v`: OZ `ECDSA.tryRecover` derives the
   ///           signer — enforcing canonical low-`s` values and `v ∈ {27, 28}`
   ///           so a malleated twin of a valid signature is rejected — and we
-  ///           require `recovered == owner` AND `_owners[recovered]`.
+  ///           require `recovered == owner` AND `isOwner(recovered)`.
   ///           The recovered address is the source of truth — a malicious
   ///           signer cannot lie about identity via ECDSA.
   ///         - any other length from a contract owner: we static-call
@@ -667,7 +747,7 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     address owner,
     bytes memory sig
   ) internal view virtual returns (bool) {
-    if (!_owners[owner]) return false;
+    if (!isOwner(owner)) return false;
     if (sig.length == 65) {
       // ECDSA branch — recover and require recovered == owner.
       (address recovered, ECDSA.RecoverError err) = ECDSA.tryRecover(txHash, sig);
@@ -759,22 +839,45 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
     for (uint256 i; i < approvedLength; ) {
       unchecked {
         address approvedOwner = approved[i];
-        if (_owners[approvedOwner] && _recordVote(txHash, txnNonce, approvedOwner)) ++counted;
+        if (isOwner(approvedOwner) && _recordVote(txHash, txnNonce, approvedOwner)) ++counted;
         ++i;
       }
     }
-    if (counted >= threshold_) return true;
-    Vote[] memory votes = _decodeVotes(signatures);
-    uint256 votesLength = votes.length;
-    for (uint256 i = 0; i < votesLength; ) {
+    if (counted < threshold_) {
+      Vote[] memory votes = _decodeVotes(signatures);
+      uint256 votesLength = votes.length;
+      for (uint256 i = 0; i < votesLength; ) {
+        unchecked {
+          if (counted >= threshold_) break;
+          if (_validateVote(txHash, votes[i].owner, votes[i].sig) && _recordVote(txHash, txnNonce, votes[i].owner))
+            ++counted;
+          ++i;
+        }
+      }
+    }
+    valid = counted >= threshold_;
+    // The hash is about to execute (or be scheduled): its on-chain approvals
+    // are consumed, so clear them. This keeps `getApprovedOwners` accurate
+    // and stops stale entries (e.g. from since-removed owners) from
+    // inflating the vote-count loops of this hash forever.
+    if (valid) _pruneApprovals(txHash);
+  }
+
+  /// @notice Clears every `approveHash` record for `txHash`: each owner's
+  ///         `_approvedHashes` flag and the whole `_approvedOwners` list.
+  ///         Called once a hash reaches threshold on the mutating
+  ///         validation path — the approvals are consumed by the execution.
+  function _pruneApprovals(bytes32 txHash) internal virtual {
+    address[] storage approved = _approvedOwners[txHash];
+    uint256 n = approved.length;
+    if (n == 0) return;
+    for (uint256 i; i < n; ) {
       unchecked {
-        if (counted >= threshold_) break;
-        if (_validateVote(txHash, votes[i].owner, votes[i].sig) && _recordVote(txHash, txnNonce, votes[i].owner))
-          ++counted;
+        _approvedHashes[txHash][approved[i]] = false;
         ++i;
       }
     }
-    return counted >= threshold_;
+    delete _approvedOwners[txHash];
   }
 
   /// @notice Decodes an ABI-encoded `(address owner, bytes sig)[]` blob.
@@ -818,13 +921,14 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   /// @notice Adds an owner
   /// @param owner The address to be added as an owner.
   /// @dev This function can only be called inside a multisig transaction.
-  ///      Reverts with `NewOwnerMustNotBeZero` for the zero address — an
-  ///      `address(0)` owner slot can never vote and would only inflate
-  ///      `ownerCount`.
+  ///      Reverts with `NewOwnerMustNotBeZero` for the zero address and the
+  ///      linked-list sentinel (`address(0x1)`) — neither can ever vote,
+  ///      and both are reserved by the owners list encoding.
   function _addOwner(address owner) internal virtual {
-    if (owner == address(0)) revert NewOwnerMustNotBeZero();
-    if (_owners[owner]) revert OwnerAlreadyExists();
-    _owners[owner] = true;
+    if (owner == address(0) || owner == _SENTINEL_OWNER) revert NewOwnerMustNotBeZero();
+    if (_ownersNext[owner] != address(0)) revert OwnerAlreadyExists();
+    _ownersNext[owner] = _ownersNext[_SENTINEL_OWNER];
+    _ownersNext[_SENTINEL_OWNER] = owner;
     ++_ownerCount;
     emit OwnerAdded(owner);
   }
@@ -842,10 +946,25 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   /// @dev This function can only be called inside a multisig transaction.
 
   function _removeOwner(address owner) internal virtual {
+    if (!isOwner(owner)) revert OwnerToRemoveMustBeOwner();
     if (_ownerCount <= _threshold) revert CannotRemoveOwnerBelowThreshold();
-    _owners[owner] = false;
+    _ownersNext[_findPrevOwner(owner)] = _ownersNext[owner];
+    delete _ownersNext[owner];
     --_ownerCount;
     emit OwnerRemoved(owner);
+  }
+
+  /// @dev Walks the owners linked list to find the entry pointing at
+  ///      `owner`. The caller has already verified `owner` is a current
+  ///      owner, so the walk always terminates. O(n) SLOADs, but owner
+  ///      removal / replacement is a rare admin action.
+  function _findPrevOwner(address owner) private view returns (address prev) {
+    prev = _SENTINEL_OWNER;
+    address cursor = _ownersNext[_SENTINEL_OWNER];
+    while (cursor != owner) {
+      prev = cursor;
+      cursor = _ownersNext[cursor];
+    }
   }
 
   /// @notice Removes an owner
@@ -886,11 +1005,14 @@ contract MyMultiSig is ReentrancyGuard, EIP712, ERC721Holder, ERC1155Holder {
   /// @param newOwner The new owner.
   /// @dev This function can only be called inside a multisig transaction.
   function _replaceOwner(address oldOwner, address newOwner) internal virtual {
-    if (!_owners[oldOwner]) revert OldOwnerMustBeOwner();
-    if (_owners[newOwner]) revert NewOwnerMustNotBeOwner();
-    if (newOwner == address(0)) revert NewOwnerMustNotBeZero();
-    _owners[oldOwner] = false;
-    _owners[newOwner] = true;
+    if (!isOwner(oldOwner)) revert OldOwnerMustBeOwner();
+    if (isOwner(newOwner)) revert NewOwnerMustNotBeOwner();
+    if (newOwner == address(0) || newOwner == _SENTINEL_OWNER) revert NewOwnerMustNotBeZero();
+    // Splice the new owner into the old owner's position in the linked
+    // list, so list order is preserved.
+    _ownersNext[newOwner] = _ownersNext[oldOwner];
+    _ownersNext[_findPrevOwner(oldOwner)] = newOwner;
+    delete _ownersNext[oldOwner];
     emit OwnerRemoved(oldOwner);
     emit OwnerAdded(newOwner);
   }

--- a/contracts/MyMultiSigExtended.sol
+++ b/contracts/MyMultiSigExtended.sol
@@ -126,6 +126,12 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   error InvalidOperation(uint8 operation);
   error NotEntryPoint();
   error RequiresOperationByte();
+  /// @notice `scheduleTransaction` only accepts the wallet's current nonce:
+  ///         scheduling consumes the nonce exactly like a direct
+  ///         `execTransaction`, so a schedule signed against any other nonce
+  ///         is rejected up front instead of silently desynchronizing the
+  ///         nonce sequence.
+  error ScheduleNonceNotCurrent(uint256 provided, uint256 current);
   /// @notice The single-signer allowance path may not target the wallet
   ///         itself: a self-call would reach the `onlyThis` admin surface
   ///         with one signature instead of threshold consensus.
@@ -463,7 +469,9 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   ///         Bumps `_txnNonce` once the signatures validate — scheduling
   ///         consumes the nonce exactly like a direct `execTransaction`, so
   ///         no parallel transaction can be signed at the same nonce while
-  ///         the schedule waits out its delay.
+  ///         the schedule waits out its delay. `txnNonce` must equal the
+  ///         wallet's current `nonce()` (reverts with
+  ///         `ScheduleNonceNotCurrent` otherwise).
   function scheduleTransaction(
     address to,
     uint256 value,
@@ -474,6 +482,10 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
     bytes memory signatures
   ) public payable virtual nonReentrant returns (bytes32 txHash) {
     if (_timelockDelay == 0) revert ZeroDelayForSensitive();
+    // Scheduling consumes the wallet nonce, so only the current nonce is
+    // accepted — a custom (future or past) nonce would desynchronize the
+    // signed hash from the nonce actually consumed.
+    if (txnNonce != nonce()) revert ScheduleNonceNotCurrent(txnNonce, nonce());
     // Extended wallets sign over the 7-field typehash, so the
     // timelock-ready hash must match it. operation is locked to 0 here:
     // timelock only applies to admin calls (CALL, not DELEGATECALL).
@@ -530,7 +542,7 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
     // execute (e.g., to invalidate a pending admin call).
     if (_noncesUsed[txnNonce]) revert NonceAlreadyUsed();
 
-    success = _runLoggedCall(to, value, data, txnGas, txnNonce, validUntil);
+    success = _runLoggedCall(to, value, data, txnGas, txnNonce, txHash);
     emit ScheduledTransactionExecuted(txHash, msg.sender);
   }
 
@@ -687,7 +699,7 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
 
     _preExecChecks(to, value, data);
 
-    success = _runLoggedCall(to, value, data, txnGas, currentNonce, validUntil);
+    success = _runLoggedCall(to, value, data, txnGas, currentNonce, txHash);
     // Commit-on-success: failed inner calls don't burn the cap.
     if (success) _dailySpentByOwner[recovered] += value;
   }
@@ -695,22 +707,26 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   /// @dev Shared tail for the timelock (`executeScheduled`) and allowance
   ///      paths: run the inner call via the base `_rawCall`, bubble a
   ///      payload-carrying revert, and emit the standard success / failure
-  ///      events (+ the silent post-exec guard hook on success).
+  ///      events (+ the silent post-exec guard hook on success). `txHash` is
+  ///      the EIP-712 hash the transaction was signed over, forwarded to the
+  ///      post-exec guard.
   function _runLoggedCall(
     address to,
     uint256 value,
     bytes memory data,
     uint256 txnGas,
     uint256 txnNonce,
-    uint256 validUntil
+    bytes32 txHash
   ) internal returns (bool success) {
     bytes memory returnData;
     (success, returnData) = _rawCall(txnGas, to, value, data);
     if (success) {
       emit TransactionExecuted(msg.sender, to, value, data, txnGas, txnNonce);
-      _postExecChecks(to, value, data, txnGas, txnNonce, validUntil);
+      _postExecChecks(txHash);
     } else if (returnData.length > 0) {
       _revertWith(returnData);
+    } else if (requireTxSuccess()) {
+      revert TxSuccessRequired();
     } else {
       emit TxFailure(msg.sender, to, value, data, txnGas, txnNonce, returnData);
     }
@@ -828,6 +844,11 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   // ---------------------------------------------------------------------------
 
   /// @notice Orchestrator override: pre-checks → base path → post-check (silent).
+  ///         The post-check receives the base wallet's 6-field EIP-712 hash —
+  ///         the exact hash the owners signed — so guards can correlate
+  ///         `checkTransaction` and `checkAfterExecution` by hash. On this
+  ///         wallet the base entry points all revert `RequiresOperationByte`,
+  ///         so this override only guards subclasses that re-enable them.
   function _execTransaction(
     address to,
     uint256 value,
@@ -839,8 +860,7 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   ) internal virtual override returns (bool success) {
     _preExecChecks(to, value, data);
     success = super._execTransaction(to, value, data, txnGas, txnNonce, validUntil, signatures);
-    // `txnNonce + 1` because the base path already bumped `_txnNonce`.
-    if (success) _postExecChecks(to, value, data, txnGas, txnNonce + 1, validUntil);
+    if (success) _postExecChecks(generateHash(to, value, data, txnGas, txnNonce, validUntil));
   }
 
   /// @dev Pre-execution checks: timelock reverse-route + guard + allowlist.
@@ -874,17 +894,14 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   }
 
   /// @dev Silent post-execution hook (failure logged, never reverts).
-  function _postExecChecks(
-    address to,
-    uint256 value,
-    bytes memory data,
-    uint256 txnGas,
-    uint256 txnNoncePostBump,
-    uint256 validUntil
-  ) internal virtual {
+  ///      `txHash` is the EIP-712 hash the executed transaction was signed
+  ///      over (the 7-field op hash on the extended path, the 6-field base
+  ///      hash on the base path, the allowance hash on the allowance path),
+  ///      so guards see the same hash before and after execution.
+  function _postExecChecks(bytes32 txHash) internal virtual {
     address guardContract = _guard;
     if (guardContract != address(0)) {
-      _guardCheckAfterExecution(guardContract, generateHashOp(to, value, data, txnGas, txnNoncePostBump, validUntil, 0));
+      _guardCheckAfterExecution(guardContract, txHash);
     }
   }
 
@@ -1199,8 +1216,13 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
     if (success) {
       emit TransactionExecuted(msg.sender, to, value, data, txnGas, txnNonce);
       emit TransactionExecutedOp(msg.sender, to, value, data, txnGas, txnNonce, operation);
+      // Silent post-exec guard hook, keyed by the exact 7-field hash the
+      // owners signed so guards can correlate pre/post by hash.
+      _postExecChecks(txHash);
     } else if (returnData.length > 0) {
       _revertWith(returnData);
+    } else if (requireTxSuccess()) {
+      revert TxSuccessRequired();
     } else {
       emit TxFailure(msg.sender, to, value, data, txnGas, txnNonce, returnData);
       emit TxFailureOp(msg.sender, to, value, data, txnGas, txnNonce, operation, returnData);

--- a/contracts/test/MyMultiSigExtendedOps.t.sol
+++ b/contracts/test/MyMultiSigExtendedOps.t.sol
@@ -4,6 +4,7 @@ pragma solidity 0.8.24;
 import { Vm } from 'forge-std/Vm.sol';
 import { Helper } from './shared/helper.t.sol';
 import { MyMultiSigExtended } from '../MyMultiSigExtended.sol';
+import { MockGuard } from '../mocks/MockGuard.sol';
 import { PackedUserOperation } from '../interfaces/PackedUserOperation.sol';
 import './shared/mocks/MockEntryPoint.t.sol';
 
@@ -337,5 +338,82 @@ contract MyMultiSigExtendedTest is Helper {
   function test_execute_rejects_non_entrypoint() public {
     vm.expectRevert(abi.encodeWithSignature('NotEntryPoint()'));
     wallet.execute(address(0xa11ce), 0, '');
+  }
+
+  // ---------- post-exec guard + schedule nonce ----------
+
+  /// @dev Signs the extended 7-field (`operation`-bound) payload with both
+  ///      owners for an arbitrary nonce — `build_signatures` always signs
+  ///      the wallet's CURRENT nonce, which these tests need to deviate from.
+  function _signExtendedTx(
+    address to,
+    uint256 value,
+    bytes memory data,
+    uint256 txnGas,
+    uint256 nonce_,
+    uint8 operation
+  ) internal returns (bytes memory) {
+    bytes32 domainSeparator = build_domainSeparator(wallet, wallet.name());
+    bytes32 typehash = keccak256(
+      'Transaction(address to,uint256 value,bytes data,uint256 gas,uint96 nonce,uint256 validUntil,uint8 operation)'
+    );
+    bytes32 structHash = keccak256(
+      abi.encode(typehash, to, value, keccak256(data), txnGas, nonce_, uint256(0), operation)
+    );
+    Vote[] memory votes = new Vote[](2);
+    votes[0] = Vote({ owner: OWNERS[0], sig: signature_signHashed(OWNERS_PK[0], domainSeparator, structHash) });
+    votes[1] = Vote({ owner: OWNERS[1], sig: signature_signHashed(OWNERS_PK[1], domainSeparator, structHash) });
+    return abi.encode(votes);
+  }
+
+  function test_postExecGuard_runsOnExecPath_withSignedHash() public {
+    MockGuard guard = new MockGuard();
+    vm.prank(address(wallet));
+    wallet.setGuard(address(guard));
+    assertEq(wallet.guard(), address(guard));
+
+    vm.deal(address(wallet), 1 ether);
+    address recipient = address(0xa11ce);
+    uint256 txnGas = 50_000;
+    uint256 nonce_ = wallet.nonce();
+    bytes memory noData;
+    bytes32 signedHash = wallet.generateHashOp(recipient, 0.5 ether, noData, txnGas, nonce_, 0, 0);
+    bytes memory signatures = _signExtendedTx(recipient, 0.5 ether, noData, txnGas, nonce_, 0);
+
+    vm.prank(OWNERS[0]);
+    wallet.execTransaction(recipient, 0.5 ether, noData, txnGas, nonce_, 0, 0, signatures);
+    assertEq(recipient.balance, 0.5 ether);
+
+    // The guard's post-exec hook ran on the standard exec path and received
+    // the exact EIP-712 hash the owners signed, so pre/post can be
+    // correlated by hash.
+    assertEq(guard.checkTransactionCalls(), 1);
+    assertEq(guard.checkAfterExecutionCalls(), 1);
+    assertEq(guard.lastTxHash(), signedHash);
+    assertTrue(guard.lastSuccess());
+  }
+
+  function test_scheduleTransaction_rejectsNonCurrentNonce() public {
+    vm.prank(address(wallet));
+    wallet.setTimelockDelay(60);
+
+    bytes memory data = abi.encodeWithSignature('addOwner(address)', NOT_OWNERS[0]);
+    uint256 txnGas = 75_000;
+    uint256 wrongNonce = wallet.nonce() + 1;
+    bytes memory signatures = _signExtendedTx(address(wallet), 0, data, txnGas, wrongNonce, 0);
+
+    vm.prank(OWNERS[0]);
+    vm.expectRevert(
+      abi.encodeWithSelector(MyMultiSigExtended.ScheduleNonceNotCurrent.selector, wrongNonce, wallet.nonce())
+    );
+    wallet.scheduleTransaction(address(wallet), 0, data, txnGas, wrongNonce, 0, signatures);
+
+    // Scheduling against the CURRENT nonce goes through.
+    uint256 currentNonce = wallet.nonce();
+    signatures = _signExtendedTx(address(wallet), 0, data, txnGas, currentNonce, 0);
+    vm.prank(OWNERS[0]);
+    bytes32 txHash = wallet.scheduleTransaction(address(wallet), 0, data, txnGas, currentNonce, 0, signatures);
+    assertGt(wallet.scheduledReadyAt(txHash), 0);
+    assertEq(wallet.nonce(), currentNonce + 1);
   }
 }

--- a/contracts/test/shared/errors.t.sol
+++ b/contracts/test/shared/errors.t.sol
@@ -4,6 +4,7 @@ pragma solidity ^0.8.0;
 import { Test } from 'forge-std/Test.sol';
 
 import { MyMultiSig } from '../../MyMultiSig.sol';
+import { MyMultiSigExtended } from '../../MyMultiSigExtended.sol';
 
 /// @title Errors
 /// @notice Maps a `RevertStatus` enum to the exact custom-error selector emitted
@@ -29,7 +30,11 @@ contract Errors is Test {
     OldOwnerMustBeOwner,
     NewOwnerMustNotBeOwner,
     NewOwnerMustNotBeZero,
-    BatchCallFailed
+    BatchCallFailed,
+    ArrayLengthMismatch,
+    TxSuccessRequired,
+    OwnerToRemoveMustBeOwner,
+    ScheduleNonceNotCurrent
   }
 
   mapping(RevertStatus => bytes4) private _errors;
@@ -51,6 +56,10 @@ contract Errors is Test {
     _errors[RevertStatus.NewOwnerMustNotBeOwner] = MyMultiSig.NewOwnerMustNotBeOwner.selector;
     _errors[RevertStatus.NewOwnerMustNotBeZero] = MyMultiSig.NewOwnerMustNotBeZero.selector;
     _errors[RevertStatus.BatchCallFailed] = MyMultiSig.BatchCallFailed.selector;
+    _errors[RevertStatus.ArrayLengthMismatch] = MyMultiSig.ArrayLengthMismatch.selector;
+    _errors[RevertStatus.TxSuccessRequired] = MyMultiSig.TxSuccessRequired.selector;
+    _errors[RevertStatus.OwnerToRemoveMustBeOwner] = MyMultiSig.OwnerToRemoveMustBeOwner.selector;
+    _errors[RevertStatus.ScheduleNonceNotCurrent] = MyMultiSigExtended.ScheduleNonceNotCurrent.selector;
   }
 
   function _verify_revertCall(RevertStatus revertType_) internal view returns (bytes4) {

--- a/contracts/test/shared/tests.t.sol
+++ b/contracts/test/shared/tests.t.sol
@@ -603,4 +603,215 @@ abstract contract TestBasic is Helper {
     // Nonce must NOT advance — the whole tx was rolled back.
     assertEq(myMultiSig.nonce(), nonceBefore);
   }
+
+  // ---------------------------------------------------------------------
+  // getOwners (on-chain owner enumeration)
+  // ---------------------------------------------------------------------
+
+  function testMyMultiSig_getOwners_matchesInitialOwners() public {
+    address[] memory owners = myMultiSig.getOwners();
+    assertEq(owners.length, OWNERS.length);
+    assertEq(owners.length, myMultiSig.ownerCount());
+    // Every configured owner appears exactly once (order is
+    // most-recently-added first, so membership is what we assert).
+    for (uint256 i = 0; i < OWNERS.length; i++) {
+      uint256 seen;
+      for (uint256 j = 0; j < owners.length; j++) {
+        if (owners[j] == OWNERS[i]) seen++;
+      }
+      assertEq(seen, 1);
+    }
+  }
+
+  function testMyMultiSig_getOwners_tracksAddRemoveReplace() public {
+    help_addOwner(OWNERS[0], myMultiSig, OWNERS_PK, NOT_OWNERS[0]);
+    address[] memory owners = myMultiSig.getOwners();
+    assertEq(owners.length, OWNERS.length + 1);
+    // Owners are inserted at the head of the linked list.
+    assertEq(owners[0], NOT_OWNERS[0]);
+
+    help_removeOwner(OWNERS[0], myMultiSig, OWNERS_PK, NOT_OWNERS[0]);
+    owners = myMultiSig.getOwners();
+    assertEq(owners.length, OWNERS.length);
+    for (uint256 i = 0; i < owners.length; i++) {
+      assertTrue(owners[i] != NOT_OWNERS[0]);
+    }
+
+    help_replaceOwner(OWNERS[1], myMultiSig, OWNERS_PK, OWNERS[0], NOT_OWNERS[1]);
+    owners = myMultiSig.getOwners();
+    assertEq(owners.length, OWNERS.length);
+    bool foundNew;
+    for (uint256 i = 0; i < owners.length; i++) {
+      assertTrue(owners[i] != OWNERS[0]);
+      if (owners[i] == NOT_OWNERS[1]) foundNew = true;
+    }
+    assertTrue(foundNew);
+    assertEq(owners.length, myMultiSig.ownerCount());
+  }
+
+  // ---------------------------------------------------------------------
+  // ERC-165 introspection
+  // ---------------------------------------------------------------------
+
+  function testMyMultiSig_supportsInterface() public {
+    assertTrue(myMultiSig.supportsInterface(0x01ffc9a7)); // ERC-165
+    assertTrue(myMultiSig.supportsInterface(0x1626ba7e)); // EIP-1271
+    assertTrue(myMultiSig.supportsInterface(0x150b7a02)); // ERC-721 receiver
+    assertTrue(myMultiSig.supportsInterface(0x4e2312e0)); // ERC-1155 receiver
+    assertFalse(myMultiSig.supportsInterface(0xffffffff));
+  }
+
+  // ---------------------------------------------------------------------
+  // removeOwner input validation
+  // ---------------------------------------------------------------------
+
+  function testMyMultiSig_removeOwner_nonOwnerReverts() public {
+    address to = address(myMultiSig);
+    bytes memory data = build_removeOwner(NOT_OWNERS[0]);
+    uint96 nonceBefore = myMultiSig.nonce();
+    bytes memory signatures = build_signatures(myMultiSig, OWNERS_PK, to, 0, data, DEFAULT_GAS);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      to,
+      0,
+      data,
+      DEFAULT_GAS,
+      signatures,
+      nonceBefore,
+      Errors.RevertStatus.OwnerToRemoveMustBeOwner
+    );
+    // The whole exec reverted, so the nonce is untouched and the owner
+    // count is unchanged.
+    assertEq(myMultiSig.nonce(), nonceBefore);
+    assertEq(myMultiSig.ownerCount(), OWNERS.length);
+  }
+
+  // ---------------------------------------------------------------------
+  // multiRequest / multiRequestStrict array-length validation
+  // ---------------------------------------------------------------------
+
+  function testMyMultiSig_multiRequest_lengthMismatchReverts() public {
+    address[] memory to_ = new address[](2);
+    to_[0] = NOT_OWNERS[0];
+    to_[1] = NOT_OWNERS[1];
+    uint256[] memory value_ = new uint256[](1); // one entry short
+    bytes[] memory data_ = new bytes[](2);
+    uint256[] memory txGas_ = new uint256[](2);
+    txGas_[0] = 30_000;
+    txGas_[1] = 30_000;
+
+    address to = address(myMultiSig);
+    bytes memory data = build_multiRequest(to_, value_, data_, txGas_);
+    bytes memory signatures = build_signatures(myMultiSig, OWNERS_PK, to, 0, data, DEFAULT_GAS);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      to,
+      0,
+      data,
+      DEFAULT_GAS,
+      signatures,
+      myMultiSig.nonce(),
+      Errors.RevertStatus.ArrayLengthMismatch
+    );
+  }
+
+  function testMyMultiSig_multiRequestStrict_lengthMismatchReverts() public {
+    address[] memory to_ = new address[](2);
+    to_[0] = NOT_OWNERS[0];
+    to_[1] = NOT_OWNERS[1];
+    uint256[] memory value_ = new uint256[](2);
+    bytes[] memory data_ = new bytes[](1); // one entry short
+    uint256[] memory txGas_ = new uint256[](2);
+    txGas_[0] = 30_000;
+    txGas_[1] = 30_000;
+
+    address to = address(myMultiSig);
+    bytes memory data = build_multiRequestStrict(to_, value_, data_, txGas_);
+    bytes memory signatures = build_signatures(myMultiSig, OWNERS_PK, to, 0, data, DEFAULT_GAS);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      to,
+      0,
+      data,
+      DEFAULT_GAS,
+      signatures,
+      myMultiSig.nonce(),
+      Errors.RevertStatus.ArrayLengthMismatch
+    );
+  }
+
+  // ---------------------------------------------------------------------
+  // requireTxSuccess (must-succeed execution mode)
+  // ---------------------------------------------------------------------
+
+  function testMyMultiSig_requireTxSuccess_onlySelfCanToggle() public {
+    assertFalse(myMultiSig.requireTxSuccess());
+    vm.prank(OWNERS[0]);
+    verify_revertCall(Errors.RevertStatus.OnlyThisContract);
+    myMultiSig.setRequireTxSuccess(true);
+  }
+
+  function testMyMultiSig_requireTxSuccess_failedCallRevertsAndPreservesNonce() public {
+    // Enable the flag through a threshold-signed self-call.
+    address to = address(myMultiSig);
+    bytes memory enableData = abi.encodeWithSignature('setRequireTxSuccess(bool)', true);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      to,
+      0,
+      enableData,
+      DEFAULT_GAS,
+      build_signatures(myMultiSig, OWNERS_PK, to, 0, enableData, DEFAULT_GAS)
+    );
+    assertTrue(myMultiSig.requireTxSuccess());
+
+    // A silently-failing inner call (1 wei from an empty wallet) now
+    // reverts the whole exec instead of emitting TxFailure, so the nonce
+    // is preserved and the signatures stay usable.
+    uint96 nonceBefore = myMultiSig.nonce();
+    bytes memory noData;
+    bytes memory signatures = build_signatures(myMultiSig, OWNERS_PK, NOT_OWNERS[0], 1, noData, DEFAULT_GAS);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      NOT_OWNERS[0],
+      1,
+      noData,
+      DEFAULT_GAS,
+      signatures,
+      nonceBefore,
+      Errors.RevertStatus.TxSuccessRequired
+    );
+    assertEq(myMultiSig.nonce(), nonceBefore);
+  }
+
+  // ---------------------------------------------------------------------
+  // approval pruning after execution
+  // ---------------------------------------------------------------------
+
+  function testMyMultiSig_approvalsPrunedAfterExecution() public {
+    address to = address(myMultiSig);
+    bytes memory data = build_addOwner(NOT_OWNERS[0]);
+    bytes32 hash = build_execHash(data, DEFAULT_GAS, 0);
+
+    vm.prank(OWNERS[0]);
+    myMultiSig.approveHash(hash);
+    vm.prank(OWNERS[1]);
+    myMultiSig.approveHash(hash);
+    assertEq(myMultiSig.getApprovedOwners(hash).length, 2);
+
+    // Execute with no ECDSA votes: the two on-chain approvals reach the
+    // threshold on their own.
+    bytes memory noVotes = build_signatures(myMultiSig, new uint256[](0), to, 0, data, DEFAULT_GAS);
+    help_execTransaction(myMultiSig, OWNERS[0], to, 0, data, DEFAULT_GAS, noVotes);
+    assertTrue(myMultiSig.isOwner(NOT_OWNERS[0]));
+
+    // The consumed approvals are pruned, so the hash carries no stale
+    // entries (and the owners could re-approve a future hash cleanly).
+    assertEq(myMultiSig.getApprovedOwners(hash).length, 0);
+  }
 }

--- a/contracts/test/shared/tests.t.sol
+++ b/contracts/test/shared/tests.t.sol
@@ -135,6 +135,11 @@ abstract contract TestBasic is Helper {
 
     for (uint256 i = 0; i < NEW_OWNERS_COUNT; i++) {
       buildData[i] = build_removeOwner(NOT_OWNERS[i]);
+      // Removal walks the owners linked list to find the predecessor.
+      // NOT_OWNERS[0] sits ~100 nodes deep, so the first removals pay up
+      // to ~100 cold SLOADs (~210k gas) on top of the removal itself —
+      // give every inner call enough budget for a fully cold walk.
+      buildGas[i] = 400_000;
     }
 
     help_multiRequest(OWNERS[0], myMultiSig, OWNERS_PK, buildTo, buildValue, buildData, buildGas);

--- a/foundry.toml
+++ b/foundry.toml
@@ -11,6 +11,7 @@ evm_version = 'london'                                        # the evm version 
 auto_detect_solc = true                                       # enable auto-detection of the appropriate solc version to use
 optimizer = true                                              # enable or disable the solc optimizer
 optimizer_runs = 200                                          # the number of optimizer runs
+via_ir = true                                                 # compile through Yul IR — keeps MyMultiSigExtended under the EIP-170 size limit
 verbosity = 2                                                 # the verbosity of tests
 ignored_error_codes = []                                      # a list of ignored solc error codes
 fuzz_runs = 256                                               # the number of fuzz runs for tests

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -283,6 +283,9 @@ const config: HardhatUserConfig = {
             enabled: true,
             runs: 200,
           },
+          // Compile through Yul IR — keeps MyMultiSigExtended under the
+          // EIP-170 size limit. Must stay in sync with `via_ir` in foundry.toml.
+          viaIR: true,
         },
       },
     ],

--- a/test/shared/errors.ts
+++ b/test/shared/errors.ts
@@ -11,6 +11,10 @@ export default {
   NONCE_ALREADY_USED: 'NonceAlreadyUsed',
   NOT_OWNER: 'NotOwner',
   CANNOT_REMOVE_OWNERS_BELOW_THRESHOLD: 'CannotRemoveOwnerBelowThreshold',
+  ARRAY_LENGTH_MISMATCH: 'ArrayLengthMismatch',
+  TX_SUCCESS_REQUIRED: 'TxSuccessRequired',
+  OWNER_TO_REMOVE_MUST_BE_OWNER: 'OwnerToRemoveMustBeOwner',
+  SCHEDULE_NONCE_NOT_CURRENT: 'ScheduleNonceNotCurrent',
 
   THRESHOLD_MUST_BE_GREATER_THAN_ZERO: 'ThresholdMustBeGreaterThanZero',
   THRESHOLD_MUST_BE_LESS_OR_EQUAL_TO_OWNERS_COUNT: 'ThresholdMustBeLessOrEqualToOwnerCount',

--- a/test/shared/tests.ts
+++ b/test/shared/tests.ts
@@ -1191,6 +1191,181 @@ export async function MyMultiSigStandardTests(deploymentType = DeploymentType.Si
       })
     })
 
+    describe('getOwners - on-chain owner enumeration', function () {
+      it('getOwners returns every current owner', async function () {
+        const owners = await contract.getOwners()
+        expect(owners).to.have.lengthOf(3)
+        expect(owners).to.include.members([owner01.address, owner02.address, owner03.address])
+        expect(owners.length).to.equal(await contract.ownerCount())
+      })
+
+      it('getOwners tracks addOwner, removeOwner and replaceOwner', async function () {
+        await Helper.addOwner(contract, owner01, [owner01, owner02, owner03], user01.address)
+        let owners = await contract.getOwners()
+        expect(owners).to.have.lengthOf(4)
+        expect(owners).to.include(user01.address)
+
+        await Helper.removeOwner(contract, owner01, [owner01, owner02, owner03], user01.address, Helper.DEFAULT_GAS * 2)
+        owners = await contract.getOwners()
+        expect(owners).to.have.lengthOf(3)
+        expect(owners).to.not.include(user01.address)
+
+        await Helper.replaceOwner(
+          contract,
+          owner01,
+          [owner01, owner02, owner03],
+          user02.address,
+          owner03.address,
+          Helper.DEFAULT_GAS * 2,
+        )
+        owners = await contract.getOwners()
+        expect(owners).to.have.lengthOf(3)
+        expect(owners).to.include(user02.address)
+        expect(owners).to.not.include(owner03.address)
+      })
+
+      it('removeOwner for a non-owner reverts with OwnerToRemoveMustBeOwner', async function () {
+        const data = contract.interface.encodeFunctionData('removeOwner', [user01.address]) as `0x${string}`
+        await Helper.execTransaction(
+          contract,
+          owner01,
+          [owner01, owner02, owner03],
+          contract.address,
+          Helper.ZERO,
+          data,
+          Helper.DEFAULT_GAS,
+          Helper.errors.OWNER_TO_REMOVE_MUST_BE_OWNER,
+        )
+        expect(await contract.ownerCount()).to.equal(3)
+      })
+    })
+
+    describe('ERC-165 introspection', function () {
+      it('supportsInterface advertises ERC-165, EIP-1271 and the token receiver hooks', async function () {
+        expect(await contract.supportsInterface('0x01ffc9a7')).to.be.true // ERC-165
+        expect(await contract.supportsInterface('0x1626ba7e')).to.be.true // EIP-1271
+        expect(await contract.supportsInterface('0x150b7a02')).to.be.true // ERC-721 receiver
+        expect(await contract.supportsInterface('0x4e2312e0')).to.be.true // ERC-1155 receiver
+        expect(await contract.supportsInterface('0xffffffff')).to.be.false
+      })
+    })
+
+    describe('multiRequest - array-length validation', function () {
+      it('multiRequest with mismatched array lengths reverts with ArrayLengthMismatch', async function () {
+        const data = contract.interface.encodeFunctionData('multiRequest', [
+          [user01.address, user02.address],
+          [0], // one entry short
+          ['0x', '0x'],
+          [30000, 30000],
+        ]) as `0x${string}`
+        await Helper.execTransaction(
+          contract,
+          owner01,
+          [owner01, owner02, owner03],
+          contract.address,
+          Helper.ZERO,
+          data,
+          Helper.DEFAULT_GAS,
+          Helper.errors.ARRAY_LENGTH_MISMATCH,
+        )
+      })
+
+      it('multiRequestStrict with mismatched array lengths reverts with ArrayLengthMismatch', async function () {
+        const data = contract.interface.encodeFunctionData('multiRequestStrict', [
+          [user01.address, user02.address],
+          [0, 0],
+          ['0x'], // one entry short
+          [30000, 30000],
+        ]) as `0x${string}`
+        await Helper.execTransaction(
+          contract,
+          owner01,
+          [owner01, owner02, owner03],
+          contract.address,
+          Helper.ZERO,
+          data,
+          Helper.DEFAULT_GAS,
+          Helper.errors.ARRAY_LENGTH_MISMATCH,
+        )
+      })
+    })
+
+    describe('requireTxSuccess - must-succeed execution mode', function () {
+      it('defaults to false and cannot be toggled directly', async function () {
+        expect(await contract.requireTxSuccess()).to.be.false
+        await expect(contract.connect(owner01).setRequireTxSuccess(true)).to.be.revertedWithCustomError(
+          contract,
+          Helper.errors.ONLY_SELF,
+        )
+      })
+
+      it('a failed inner call reverts the exec and preserves the nonce once enabled', async function () {
+        const enableData = contract.interface.encodeFunctionData('setRequireTxSuccess', [true]) as `0x${string}`
+        await Helper.execTransaction(
+          contract,
+          owner01,
+          [owner01, owner02, owner03],
+          contract.address,
+          Helper.ZERO,
+          enableData,
+          Helper.DEFAULT_GAS,
+        )
+        expect(await contract.requireTxSuccess()).to.be.true
+
+        // 1 wei from an empty wallet fails silently; the exec must now
+        // revert instead of emitting TxFailure, keeping the nonce (and the
+        // collected signatures) intact.
+        const nonceBefore = await contract.nonce()
+        await Helper.execTransaction(
+          contract,
+          owner01,
+          [owner01, owner02, owner03],
+          user01.address,
+          ethers.utils.parseEther('1'),
+          '0x',
+          Helper.DEFAULT_GAS,
+          Helper.errors.TX_SUCCESS_REQUIRED,
+        )
+        expect(await contract.nonce()).to.equal(nonceBefore)
+      })
+    })
+
+    describe('approval pruning after execution', function () {
+      it('on-chain approvals are cleared once the transaction executes', async function () {
+        const data = contract.interface.encodeFunctionData('addOwner(address)', [user01.address]) as `0x${string}`
+        const hash = await Helper.generateHashForWallet(
+          contract,
+          contract.address,
+          Helper.ZERO,
+          data,
+          Helper.DEFAULT_GAS,
+          ethers.BigNumber.from(0),
+          0,
+        )
+        await Helper.approveHash(contract, owner01, hash)
+        await Helper.approveHash(contract, owner02, hash)
+        expect(await contract.getApprovedOwners(hash)).to.have.lengthOf(2)
+
+        // Execute with no ECDSA votes: the two approvals reach the threshold.
+        const emptyVotes = ethers.utils.defaultAbiCoder.encode(['tuple(address owner, bytes sig)[]'], [[]])
+        await Helper.execTransaction(
+          contract,
+          owner01,
+          [],
+          contract.address,
+          Helper.ZERO,
+          data,
+          Helper.DEFAULT_GAS,
+          undefined,
+          ['OwnerAdded'],
+          emptyVotes,
+        )
+        expect(await contract.isOwner(user01.address)).to.be.true
+        // The consumed approvals were pruned with the execution.
+        expect(await contract.getApprovedOwners(hash)).to.have.lengthOf(0)
+      })
+    })
+
     describe('signMessage - on-chain typed-data auth (EIP-1271)', function () {
       const MAGIC = '0x1626ba7e'
       const NOT_MAGIC = '0xffffffff'
@@ -1762,7 +1937,16 @@ export async function MyMultiSigExtendedTests(deploymentType = DeploymentType.Si
         ethers.BigNumber.from(60).mul(60).mul(24).mul(7),
       )
       await Helper.setOwnerSettings(contract, owner01.address, owner01, [owner01, owner02, owner03], eightDays, user02.address)
-      await Helper.replaceOwner(contract, owner01, [owner01, owner02, owner03], user01.address, owner01.address)
+      // Owner replacement pays for the delegate release plus the owners
+      // linked-list splice, so it needs more than the default inner budget.
+      await Helper.replaceOwner(
+        contract,
+        owner01,
+        [owner01, owner02, owner03],
+        user01.address,
+        owner01.address,
+        Helper.DEFAULT_GAS * 2,
+      )
       await Helper.setOwnerSettings(contract, owner02.address, owner02, [owner02, owner03, user01], eightDays, user02.address)
     })
 
@@ -2785,6 +2969,30 @@ export async function MyMultiSigAdvancedTests(deploymentType = DeploymentType.Si
         ).to.be.revertedWithCustomError(contract, 'NotScheduled')
       })
 
+      it('scheduleTransaction rejects a nonce that is not the current one', async function () {
+        await Helper.setTimelockDelay(contract, owner01, [owner01, owner02], 60)
+        const data = contract.interface.encodeFunctionData('addOwner(address)', [user01.address])
+        const nonce = await contract.nonce()
+        const wrongNonce = nonce.add(1)
+        const signatures = await Helper.prepareSignatures(
+          contract,
+          [owner01, owner02],
+          contract.address,
+          Helper.ZERO,
+          data,
+          Helper.DEFAULT_GAS,
+          wrongNonce,
+          0,
+        )
+        await expect(
+          contract
+            .connect(owner01)
+            .scheduleTransaction(contract.address, Helper.ZERO, data, Helper.DEFAULT_GAS, wrongNonce, 0, signatures),
+        ).to.be.revertedWithCustomError(contract, Helper.errors.SCHEDULE_NONCE_NOT_CURRENT)
+        // Nothing was consumed: the nonce is untouched.
+        expect(await contract.nonce()).to.equal(nonce)
+      })
+
       it('cancelScheduled by hash clears a pending schedule', async function () {
         await Helper.setTimelockDelay(contract, owner01, [owner01, owner02], 60)
         const data = contract.interface.encodeFunctionData('addOwner(address)', [user01.address])
@@ -2933,6 +3141,41 @@ export async function MyMultiSigAdvancedTests(deploymentType = DeploymentType.Si
         )
         const after = await ethers.provider.getBalance(recipient)
         expect(after.sub(before)).to.be.equal(ethers.utils.parseEther('0.1'))
+      })
+
+      it('post-exec guard hook runs on the standard exec path with the signed hash', async function () {
+        const Guard = await ethers.getContractFactory('MockGuard')
+        const guard = await Guard.deploy()
+        await guard.deployed()
+        await Helper.setGuard(contract, owner01, [owner01, owner02], guard.address)
+        const callsBefore = await guard.checkAfterExecutionCalls()
+
+        const nonce = await contract.nonce()
+        const data = '0x'
+        const expectedHash = await contract.generateHashOp(
+          user01.address,
+          Helper.ZERO,
+          data,
+          Helper.DEFAULT_GAS,
+          nonce,
+          0,
+          0,
+        )
+        await Helper.execTransaction(
+          contract,
+          owner01,
+          [owner01, owner02],
+          user01.address,
+          Helper.ZERO,
+          data as `0x${string}`,
+          Helper.DEFAULT_GAS,
+        )
+        // `checkAfterExecution` ran once for this exec and received the
+        // exact EIP-712 hash the owners signed, so guards can correlate
+        // `checkTransaction` and `checkAfterExecution` by hash.
+        expect(await guard.checkAfterExecutionCalls()).to.equal(callsBefore.add(1))
+        expect(await guard.lastTxHash()).to.equal(expectedHash)
+        expect(await guard.lastSuccess()).to.be.true
       })
 
       it('rejective guard wraps the inner revert into GuardReverted', async function () {

--- a/types/MyMultiSig.ts
+++ b/types/MyMultiSig.ts
@@ -39,6 +39,7 @@ export interface MyMultiSigInterface extends utils.Interface {
     "generateHash(address,uint256,bytes,uint256,uint256,uint256)": FunctionFragment;
     "getApprovedOwners(bytes32)": FunctionFragment;
     "getMessageHash(bytes)": FunctionFragment;
+    "getOwners()": FunctionFragment;
     "getThreshold(bytes32)": FunctionFragment;
     "incrementNonce()": FunctionFragment;
     "isMessageSigned(bytes32)": FunctionFragment;
@@ -55,7 +56,9 @@ export interface MyMultiSigInterface extends utils.Interface {
     "ownerCount()": FunctionFragment;
     "removeOwner(address)": FunctionFragment;
     "replaceOwner(address,address)": FunctionFragment;
+    "requireTxSuccess()": FunctionFragment;
     "revokeApproval(bytes32)": FunctionFragment;
+    "setRequireTxSuccess(bool)": FunctionFragment;
     "signMessage(bytes)": FunctionFragment;
     "supportsInterface(bytes4)": FunctionFragment;
     "threshold()": FunctionFragment;
@@ -74,6 +77,7 @@ export interface MyMultiSigInterface extends utils.Interface {
       | "generateHash"
       | "getApprovedOwners"
       | "getMessageHash"
+      | "getOwners"
       | "getThreshold"
       | "incrementNonce"
       | "isMessageSigned"
@@ -90,7 +94,9 @@ export interface MyMultiSigInterface extends utils.Interface {
       | "ownerCount"
       | "removeOwner"
       | "replaceOwner"
+      | "requireTxSuccess"
       | "revokeApproval"
+      | "setRequireTxSuccess"
       | "signMessage"
       | "supportsInterface"
       | "threshold"
@@ -154,6 +160,7 @@ export interface MyMultiSigInterface extends utils.Interface {
     functionFragment: "getMessageHash",
     values: [PromiseOrValue<BytesLike>]
   ): string;
+  encodeFunctionData(functionFragment: "getOwners", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "getThreshold",
     values: [PromiseOrValue<BytesLike>]
@@ -248,8 +255,16 @@ export interface MyMultiSigInterface extends utils.Interface {
     values: [PromiseOrValue<string>, PromiseOrValue<string>]
   ): string;
   encodeFunctionData(
+    functionFragment: "requireTxSuccess",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
     functionFragment: "revokeApproval",
     values: [PromiseOrValue<BytesLike>]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setRequireTxSuccess",
+    values: [PromiseOrValue<boolean>]
   ): string;
   encodeFunctionData(
     functionFragment: "signMessage",
@@ -299,6 +314,7 @@ export interface MyMultiSigInterface extends utils.Interface {
     functionFragment: "getMessageHash",
     data: BytesLike
   ): Result;
+  decodeFunctionResult(functionFragment: "getOwners", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "getThreshold",
     data: BytesLike
@@ -352,7 +368,15 @@ export interface MyMultiSigInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
+    functionFragment: "requireTxSuccess",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "revokeApproval",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setRequireTxSuccess",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -379,6 +403,7 @@ export interface MyMultiSigInterface extends utils.Interface {
     "MultiRequestExecuted(uint256,bool[],bytes[])": EventFragment;
     "OwnerAdded(address)": EventFragment;
     "OwnerRemoved(address)": EventFragment;
+    "RequireTxSuccessSet(bool)": EventFragment;
     "RevokeApproval(address,bytes32)": EventFragment;
     "ThresholdChanged(uint256)": EventFragment;
     "TransactionExecuted(address,address,uint256,bytes,uint256,uint256)": EventFragment;
@@ -393,6 +418,7 @@ export interface MyMultiSigInterface extends utils.Interface {
   getEvent(nameOrSignatureOrTopic: "MultiRequestExecuted"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OwnerAdded"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OwnerRemoved"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "RequireTxSuccessSet"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "RevokeApproval"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "ThresholdChanged"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "TransactionExecuted"): EventFragment;
@@ -473,6 +499,17 @@ export interface OwnerRemovedEventObject {
 export type OwnerRemovedEvent = TypedEvent<[string], OwnerRemovedEventObject>;
 
 export type OwnerRemovedEventFilter = TypedEventFilter<OwnerRemovedEvent>;
+
+export interface RequireTxSuccessSetEventObject {
+  required: boolean;
+}
+export type RequireTxSuccessSetEvent = TypedEvent<
+  [boolean],
+  RequireTxSuccessSetEventObject
+>;
+
+export type RequireTxSuccessSetEventFilter =
+  TypedEventFilter<RequireTxSuccessSetEvent>;
 
 export interface RevokeApprovalEventObject {
   owner: string;
@@ -623,6 +660,10 @@ export interface MyMultiSig extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string]>;
 
+    getOwners(
+      overrides?: CallOverrides
+    ): Promise<[string[]] & { owners: string[] }>;
+
     getThreshold(
       arg0: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
@@ -718,8 +759,15 @@ export interface MyMultiSig extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
+    requireTxSuccess(overrides?: CallOverrides): Promise<[boolean]>;
+
     revokeApproval(
       hash: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setRequireTxSuccess(
+      required: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
@@ -810,6 +858,8 @@ export interface MyMultiSig extends BaseContract {
     message: PromiseOrValue<BytesLike>,
     overrides?: CallOverrides
   ): Promise<string>;
+
+  getOwners(overrides?: CallOverrides): Promise<string[]>;
 
   getThreshold(
     arg0: PromiseOrValue<BytesLike>,
@@ -906,8 +956,15 @@ export interface MyMultiSig extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  requireTxSuccess(overrides?: CallOverrides): Promise<boolean>;
+
   revokeApproval(
     hash: PromiseOrValue<BytesLike>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setRequireTxSuccess(
+    required: PromiseOrValue<boolean>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
@@ -998,6 +1055,8 @@ export interface MyMultiSig extends BaseContract {
       message: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<string>;
+
+    getOwners(overrides?: CallOverrides): Promise<string[]>;
 
     getThreshold(
       arg0: PromiseOrValue<BytesLike>,
@@ -1094,8 +1153,15 @@ export interface MyMultiSig extends BaseContract {
       overrides?: CallOverrides
     ): Promise<void>;
 
+    requireTxSuccess(overrides?: CallOverrides): Promise<boolean>;
+
     revokeApproval(
       hash: PromiseOrValue<BytesLike>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setRequireTxSuccess(
+      required: PromiseOrValue<boolean>,
       overrides?: CallOverrides
     ): Promise<void>;
 
@@ -1175,6 +1241,11 @@ export interface MyMultiSig extends BaseContract {
     OwnerRemoved(
       owner?: PromiseOrValue<string> | null
     ): OwnerRemovedEventFilter;
+
+    "RequireTxSuccessSet(bool)"(
+      required?: null
+    ): RequireTxSuccessSetEventFilter;
+    RequireTxSuccessSet(required?: null): RequireTxSuccessSetEventFilter;
 
     "RevokeApproval(address,bytes32)"(
       owner?: PromiseOrValue<string> | null,
@@ -1286,6 +1357,8 @@ export interface MyMultiSig extends BaseContract {
       overrides?: CallOverrides
     ): Promise<BigNumber>;
 
+    getOwners(overrides?: CallOverrides): Promise<BigNumber>;
+
     getThreshold(
       arg0: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
@@ -1381,8 +1454,15 @@ export interface MyMultiSig extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
+    requireTxSuccess(overrides?: CallOverrides): Promise<BigNumber>;
+
     revokeApproval(
       hash: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setRequireTxSuccess(
+      required: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
@@ -1462,6 +1542,8 @@ export interface MyMultiSig extends BaseContract {
       message: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
     ): Promise<PopulatedTransaction>;
+
+    getOwners(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
     getThreshold(
       arg0: PromiseOrValue<BytesLike>,
@@ -1558,8 +1640,15 @@ export interface MyMultiSig extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
+    requireTxSuccess(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
     revokeApproval(
       hash: PromiseOrValue<BytesLike>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setRequireTxSuccess(
+      required: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 

--- a/types/MyMultiSigExtended.ts
+++ b/types/MyMultiSigExtended.ts
@@ -108,6 +108,7 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     "getApprovedOwners(bytes32)": FunctionFragment;
     "getMessageHash(bytes)": FunctionFragment;
     "getModules()": FunctionFragment;
+    "getOwners()": FunctionFragment;
     "getThreshold(bytes32)": FunctionFragment;
     "guard()": FunctionFragment;
     "incrementNonce()": FunctionFragment;
@@ -134,6 +135,7 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     "ownerSettings(address)": FunctionFragment;
     "removeOwner(address)": FunctionFragment;
     "replaceOwner(address,address)": FunctionFragment;
+    "requireTxSuccess()": FunctionFragment;
     "revokeApproval(bytes32)": FunctionFragment;
     "scheduleTransaction(address,uint256,bytes,uint256,uint256,uint256,bytes)": FunctionFragment;
     "scheduledReadyAt(bytes32)": FunctionFragment;
@@ -144,6 +146,7 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     "setGuard(address)": FunctionFragment;
     "setOnlyOwnerRequest(bool)": FunctionFragment;
     "setOwnerSettings(address,uint256,address)": FunctionFragment;
+    "setRequireTxSuccess(bool)": FunctionFragment;
     "setSensitiveSelector(bytes4,bool)": FunctionFragment;
     "setSensitiveValueThreshold(uint256)": FunctionFragment;
     "setTimelockDelay(uint256)": FunctionFragment;
@@ -192,6 +195,7 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
       | "getApprovedOwners"
       | "getMessageHash"
       | "getModules"
+      | "getOwners"
       | "getThreshold"
       | "guard"
       | "incrementNonce"
@@ -218,6 +222,7 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
       | "ownerSettings"
       | "removeOwner"
       | "replaceOwner"
+      | "requireTxSuccess"
       | "revokeApproval"
       | "scheduleTransaction"
       | "scheduledReadyAt"
@@ -228,6 +233,7 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
       | "setGuard"
       | "setOnlyOwnerRequest"
       | "setOwnerSettings"
+      | "setRequireTxSuccess"
       | "setSensitiveSelector"
       | "setSensitiveValueThreshold"
       | "setTimelockDelay"
@@ -447,6 +453,7 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     functionFragment: "getModules",
     values?: undefined
   ): string;
+  encodeFunctionData(functionFragment: "getOwners", values?: undefined): string;
   encodeFunctionData(
     functionFragment: "getThreshold",
     values: [PromiseOrValue<BytesLike>]
@@ -587,6 +594,10 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     values: [PromiseOrValue<string>, PromiseOrValue<string>]
   ): string;
   encodeFunctionData(
+    functionFragment: "requireTxSuccess",
+    values?: undefined
+  ): string;
+  encodeFunctionData(
     functionFragment: "revokeApproval",
     values: [PromiseOrValue<BytesLike>]
   ): string;
@@ -637,6 +648,10 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
       PromiseOrValue<BigNumberish>,
       PromiseOrValue<string>
     ]
+  ): string;
+  encodeFunctionData(
+    functionFragment: "setRequireTxSuccess",
+    values: [PromiseOrValue<boolean>]
   ): string;
   encodeFunctionData(
     functionFragment: "setSensitiveSelector",
@@ -804,6 +819,7 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(functionFragment: "getModules", data: BytesLike): Result;
+  decodeFunctionResult(functionFragment: "getOwners", data: BytesLike): Result;
   decodeFunctionResult(
     functionFragment: "getThreshold",
     data: BytesLike
@@ -888,6 +904,10 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     data: BytesLike
   ): Result;
   decodeFunctionResult(
+    functionFragment: "requireTxSuccess",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
     functionFragment: "revokeApproval",
     data: BytesLike
   ): Result;
@@ -922,6 +942,10 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
   ): Result;
   decodeFunctionResult(
     functionFragment: "setOwnerSettings",
+    data: BytesLike
+  ): Result;
+  decodeFunctionResult(
+    functionFragment: "setRequireTxSuccess",
     data: BytesLike
   ): Result;
   decodeFunctionResult(
@@ -992,6 +1016,7 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
     "OwnerAdded(address)": EventFragment;
     "OwnerRemoved(address)": EventFragment;
     "PostExecutionGuardFailed(address,bytes)": EventFragment;
+    "RequireTxSuccessSet(bool)": EventFragment;
     "RevokeApproval(address,bytes32)": EventFragment;
     "ScheduledTransactionCancelled(bytes32,address)": EventFragment;
     "ScheduledTransactionExecuted(bytes32,address)": EventFragment;
@@ -1022,6 +1047,7 @@ export interface MyMultiSigExtendedInterface extends utils.Interface {
   getEvent(nameOrSignatureOrTopic: "OwnerAdded"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "OwnerRemoved"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "PostExecutionGuardFailed"): EventFragment;
+  getEvent(nameOrSignatureOrTopic: "RequireTxSuccessSet"): EventFragment;
   getEvent(nameOrSignatureOrTopic: "RevokeApproval"): EventFragment;
   getEvent(
     nameOrSignatureOrTopic: "ScheduledTransactionCancelled"
@@ -1199,6 +1225,17 @@ export type PostExecutionGuardFailedEvent = TypedEvent<
 
 export type PostExecutionGuardFailedEventFilter =
   TypedEventFilter<PostExecutionGuardFailedEvent>;
+
+export interface RequireTxSuccessSetEventObject {
+  required: boolean;
+}
+export type RequireTxSuccessSetEvent = TypedEvent<
+  [boolean],
+  RequireTxSuccessSetEventObject
+>;
+
+export type RequireTxSuccessSetEventFilter =
+  TypedEventFilter<RequireTxSuccessSetEvent>;
 
 export interface RevokeApprovalEventObject {
   owner: string;
@@ -1590,6 +1627,10 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: CallOverrides
     ): Promise<[string[]] & { modules: string[] }>;
 
+    getOwners(
+      overrides?: CallOverrides
+    ): Promise<[string[]] & { owners: string[] }>;
+
     getThreshold(
       arg0: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
@@ -1735,6 +1776,8 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
+    requireTxSuccess(overrides?: CallOverrides): Promise<[boolean]>;
+
     revokeApproval(
       hash: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -1789,6 +1832,11 @@ export interface MyMultiSigExtended extends BaseContract {
       owner: PromiseOrValue<string>,
       transferInactiveOwnershipAfter: PromiseOrValue<BigNumberish>,
       delegatee: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<ContractTransaction>;
+
+    setRequireTxSuccess(
+      required: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<ContractTransaction>;
 
@@ -2057,6 +2105,8 @@ export interface MyMultiSigExtended extends BaseContract {
 
   getModules(overrides?: CallOverrides): Promise<string[]>;
 
+  getOwners(overrides?: CallOverrides): Promise<string[]>;
+
   getThreshold(
     arg0: PromiseOrValue<BytesLike>,
     overrides?: CallOverrides
@@ -2202,6 +2252,8 @@ export interface MyMultiSigExtended extends BaseContract {
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
+  requireTxSuccess(overrides?: CallOverrides): Promise<boolean>;
+
   revokeApproval(
     hash: PromiseOrValue<BytesLike>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -2256,6 +2308,11 @@ export interface MyMultiSigExtended extends BaseContract {
     owner: PromiseOrValue<string>,
     transferInactiveOwnershipAfter: PromiseOrValue<BigNumberish>,
     delegatee: PromiseOrValue<string>,
+    overrides?: Overrides & { from?: PromiseOrValue<string> }
+  ): Promise<ContractTransaction>;
+
+  setRequireTxSuccess(
+    required: PromiseOrValue<boolean>,
     overrides?: Overrides & { from?: PromiseOrValue<string> }
   ): Promise<ContractTransaction>;
 
@@ -2522,6 +2579,8 @@ export interface MyMultiSigExtended extends BaseContract {
 
     getModules(overrides?: CallOverrides): Promise<string[]>;
 
+    getOwners(overrides?: CallOverrides): Promise<string[]>;
+
     getThreshold(
       arg0: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
@@ -2667,6 +2726,8 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: CallOverrides
     ): Promise<void>;
 
+    requireTxSuccess(overrides?: CallOverrides): Promise<boolean>;
+
     revokeApproval(
       hash: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
@@ -2721,6 +2782,11 @@ export interface MyMultiSigExtended extends BaseContract {
       owner: PromiseOrValue<string>,
       transferInactiveOwnershipAfter: PromiseOrValue<BigNumberish>,
       delegatee: PromiseOrValue<string>,
+      overrides?: CallOverrides
+    ): Promise<void>;
+
+    setRequireTxSuccess(
+      required: PromiseOrValue<boolean>,
       overrides?: CallOverrides
     ): Promise<void>;
 
@@ -2911,6 +2977,11 @@ export interface MyMultiSigExtended extends BaseContract {
       guard?: PromiseOrValue<string> | null,
       reason?: null
     ): PostExecutionGuardFailedEventFilter;
+
+    "RequireTxSuccessSet(bool)"(
+      required?: null
+    ): RequireTxSuccessSetEventFilter;
+    RequireTxSuccessSet(required?: null): RequireTxSuccessSetEventFilter;
 
     "RevokeApproval(address,bytes32)"(
       owner?: PromiseOrValue<string> | null,
@@ -3242,6 +3313,8 @@ export interface MyMultiSigExtended extends BaseContract {
 
     getModules(overrides?: CallOverrides): Promise<BigNumber>;
 
+    getOwners(overrides?: CallOverrides): Promise<BigNumber>;
+
     getThreshold(
       arg0: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
@@ -3387,6 +3460,8 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
+    requireTxSuccess(overrides?: CallOverrides): Promise<BigNumber>;
+
     revokeApproval(
       hash: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -3441,6 +3516,11 @@ export interface MyMultiSigExtended extends BaseContract {
       owner: PromiseOrValue<string>,
       transferInactiveOwnershipAfter: PromiseOrValue<BigNumberish>,
       delegatee: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<BigNumber>;
+
+    setRequireTxSuccess(
+      required: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<BigNumber>;
 
@@ -3704,6 +3784,8 @@ export interface MyMultiSigExtended extends BaseContract {
 
     getModules(overrides?: CallOverrides): Promise<PopulatedTransaction>;
 
+    getOwners(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
     getThreshold(
       arg0: PromiseOrValue<BytesLike>,
       overrides?: CallOverrides
@@ -3849,6 +3931,8 @@ export interface MyMultiSigExtended extends BaseContract {
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 
+    requireTxSuccess(overrides?: CallOverrides): Promise<PopulatedTransaction>;
+
     revokeApproval(
       hash: PromiseOrValue<BytesLike>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
@@ -3905,6 +3989,11 @@ export interface MyMultiSigExtended extends BaseContract {
       owner: PromiseOrValue<string>,
       transferInactiveOwnershipAfter: PromiseOrValue<BigNumberish>,
       delegatee: PromiseOrValue<string>,
+      overrides?: Overrides & { from?: PromiseOrValue<string> }
+    ): Promise<PopulatedTransaction>;
+
+    setRequireTxSuccess(
+      required: PromiseOrValue<boolean>,
       overrides?: Overrides & { from?: PromiseOrValue<string> }
     ): Promise<PopulatedTransaction>;
 


### PR DESCRIPTION
## Summary

Fixes the 8 outstanding bugs/gaps from the v0.5 review:

1. **Post-exec guard now runs on the main Extended path** — `_execExtended` (every operation-carrying `execTransaction`) calls the silent `checkAfterExecution` hook on success, matching the module / ERC-4337 / scheduled / allowance paths. The dead `_execTransaction` override is kept (solc prunes it) but fixed for subclasses that re-enable the base entry points.
2. **Post-exec hash matches the signed hash** — the guard receives the exact EIP-712 hash the owners signed (7-field op hash on the extended path, 6-field base hash, allowance hash) instead of a hash rebuilt with `txnNonce + 1` that was never signed, so guards can correlate pre/post by hash.
3. **`getOwners()`** — owners are stored as a sentinel-headed linked list (Safe-style, same pattern as the modules list) and enumerable on-chain. Chosen over an array + index mapping because it only adds ~5k gas per `addOwner` instead of ~60k. As a required side fix, `removeOwner` now rejects non-owners with `OwnerToRemoveMustBeOwner` (it previously decremented `ownerCount` for any address).
4. **Opt-in must-succeed mode** — `setRequireTxSuccess(true)` (onlyThis) makes a silently-failing inner call revert the whole exec with `TxSuccessRequired`, so the nonce is preserved and a carefully collected signature set can't be burned by a bad call. Default off — existing `TxFailure` soft-fail semantics are unchanged.
5. **`ArrayLengthMismatch`** — explicit length checks in `multiRequest` / `multiRequestStrict` instead of opaque OOB reverts.
6. **EIP-1271 declared + advertised** — `MyMultiSig is IERC1271`, and `supportsInterface` answers for `0x1626ba7e`, the ERC-721/1155 receiver hooks and ERC-165 itself.
7. **Approval pruning** — once a hash reaches threshold on the mutating validation path (exec or schedule), its `_approvedOwners` / `_approvedHashes` entries are cleared: consumed approvals (including ones from since-removed owners) no longer inflate that hash's vote loops forever.
8. **`scheduleTransaction` pins the current nonce** — scheduling consumes the current nonce, so signing against any other nonce now reverts with `ScheduleNonceNotCurrent` instead of silently desynchronizing.

## Toolchain note: via-IR

`MyMultiSigExtended` sat at a **42-byte margin** under EIP-170 on main, so these additions could not fit through the legacy pipeline (+1.3k bytes). Both toolchains now compile through via-IR (`viaIR: true` in hardhat.config.ts, `via_ir = true` in foundry.toml), bringing the wallet to ~22.6k bytes with ~2k of headroom for future work. The extended *deployer* remains over the limit as it was on main (improved from −3,932 to −2,539 bytes).

## Testing

- `forge test`: 191 passing (29 new)
- `npx hardhat test`: 366 passing (24 new; one existing test's inner gas budget doubled to pay for the owners-list splice)
- `forge build --sizes`: MyMultiSig 11,798 · MyMultiSigExtended 22,584 (margin 1,992)

## Not in scope (from the same review)

Relayer gas refund, multi-guardian social recovery, EntryPoint deposit helpers, `nonReentrant` on `execTransactionFromModule`, and the README/docs refresh — left for follow-up PRs since they are new features rather than fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)