### PR TITLE
fix: module entry-point guards and failure-policy docs

### DIFF
--- a/contracts/MyMultiSig.sol
+++ b/contracts/MyMultiSig.sol
@@ -38,10 +38,15 @@ contract MyMultiSig is ReentrancyGuard, EIP712, IERC1271, ERC721Holder, ERC1155H
   ///         EIP-1271 `isValidSignature(bytes32,bytes)` empty-signature path.
   mapping(bytes32 => bool) private _signedMessages;
 
-  /// @notice When true, an inner call that fails inside `execTransaction`
-  ///         reverts the whole transaction (`TxSuccessRequired`) instead of
-  ///         emitting `TxFailure` — so the nonce is not consumed and the
-  ///         collected signatures stay usable for a retry.
+  /// @notice Failure-policy flag for inner calls that fail WITHOUT revert
+  ///         data (e.g. an ETH transfer bouncing off an insufficient
+  ///         balance). When true, such a failure reverts the whole
+  ///         `execTransaction` (`TxSuccessRequired`) — the nonce is not
+  ///         consumed and the collected signatures stay usable for a retry.
+  ///         When false, the failure is soft: `TxFailure` is emitted and the
+  ///         nonce IS consumed. Inner calls that fail WITH revert data are
+  ///         not governed by this flag — their payload always bubbles up and
+  ///         reverts the whole transaction (see `_execTransaction`).
   bool private _requireTxSuccess;
 
   /// @notice Sentinel head/tail of the owners linked list. Never a valid
@@ -88,11 +93,14 @@ contract MyMultiSig is ReentrancyGuard, EIP712, IERC1271, ERC721Holder, ERC1155H
     uint256 txnGas,
     uint256 txnNonce
   );
-  /// @notice Emitted when a transaction is executed but the low-level call to
-  ///         `to` returned `false`. `reason` carries the raw return data of the
-  ///         failed call so front-ends can decode the target's revert reason and
-  ///         distinguish an on-chain revert from a signature or gas failure
-  ///         (those revert the whole `execTransaction` with a distinct custom error).
+  /// @notice Emitted when the signatures validated but the low-level call to
+  ///         `to` failed WITHOUT revert data (e.g. a plain ETH transfer
+  ///         bouncing, or the target running out of its forwarded gas) while
+  ///         `requireTxSuccess()` is off. The nonce is consumed on this path.
+  ///         A failed inner call that DOES return revert data never reaches
+  ///         this event: its payload is bubbled up and the whole
+  ///         `execTransaction` reverts, preserving the nonce — so `reason`
+  ///         is empty bytes by construction whenever this event fires.
   event TxFailure(
     address indexed sender,
     address indexed to,
@@ -161,9 +169,11 @@ contract MyMultiSig is ReentrancyGuard, EIP712, IERC1271, ERC721Holder, ERC1155H
   ///         different lengths — every batch array must have one entry per
   ///         inner call.
   error ArrayLengthMismatch();
-  /// @notice The inner call failed while `requireTxSuccess()` is enabled.
-  ///         The whole `execTransaction` reverts, so the nonce is not
-  ///         consumed and the collected signatures stay usable.
+  /// @notice The inner call failed without revert data while
+  ///         `requireTxSuccess()` is enabled. The whole `execTransaction`
+  ///         reverts, so the nonce is not consumed and the collected
+  ///         signatures stay usable. (An inner failure WITH revert data
+  ///         bubbles that payload instead of this error.)
   error TxSuccessRequired();
   /// @notice `removeOwner` was called for an address that is not a current
   ///         owner.
@@ -253,17 +263,28 @@ contract MyMultiSig is ReentrancyGuard, EIP712, IERC1271, ERC721Holder, ERC1155H
     }
   }
 
-  /// @notice Whether must-succeed execution mode is on. When enabled, a
-  ///         failed inner call reverts the whole `execTransaction` with
-  ///         `TxSuccessRequired` instead of emitting `TxFailure` and
-  ///         consuming the nonce.
+  /// @notice Whether must-succeed execution mode is on. Failure handling of
+  ///         the inner call of every exec path is:
+  ///         - fails WITH revert data: the payload bubbles up and the whole
+  ///           `execTransaction` reverts (nonce preserved) — regardless of
+  ///           this flag;
+  ///         - fails WITHOUT revert data, flag on: the whole
+  ///           `execTransaction` reverts with `TxSuccessRequired` (nonce
+  ///           preserved);
+  ///         - fails WITHOUT revert data, flag off: `TxFailure` is emitted
+  ///           and the nonce is consumed (soft failure).
   function requireTxSuccess() public view virtual returns (bool) {
     return _requireTxSuccess;
   }
 
   /// @notice Toggles must-succeed execution mode (see `requireTxSuccess`).
-  /// @param required True to revert `execTransaction` on inner-call failure.
+  /// @param required True to revert `execTransaction` when the inner call
+  ///        fails without revert data (payload-carrying failures always
+  ///        revert either way).
   /// @dev This function can only be called inside a multisig transaction.
+  ///      On `MyMultiSigExtended` this selector is part of the default
+  ///      sensitive set, so once a timelock delay is configured the toggle
+  ///      must go through `scheduleTransaction`.
   function setRequireTxSuccess(bool required) public virtual onlyThis {
     _requireTxSuccess = required;
     emit RequireTxSuccessSet(required);
@@ -463,6 +484,17 @@ contract MyMultiSig is ReentrancyGuard, EIP712, IERC1271, ERC721Holder, ERC1155H
   function _beforeInnerCall(address /* to */, uint256 /* value */, bytes memory /* data */) internal virtual {}
 
   /// @notice Executes a transaction (internal)
+  /// @dev Failure policy for the inner call, shared by every exec path of
+  ///      the wallet family:
+  ///      - success: `TransactionExecuted`, nonce consumed;
+  ///      - failed WITH revert data: the payload bubbles up unchanged and
+  ///        the whole transaction reverts — nonce preserved regardless of
+  ///        `requireTxSuccess()` — so structured inner errors (e.g.
+  ///        `multiRequestStrict`'s `BatchCallFailed`, `onlyThis` admin
+  ///        errors) stay decodable by the caller;
+  ///      - failed WITHOUT revert data: reverts `TxSuccessRequired` when
+  ///        `requireTxSuccess()` is on (nonce preserved), otherwise emits
+  ///        `TxFailure` and consumes the nonce.
   /// @param to The address to which the transaction is made.
   /// @param value The amount of Ether to be transferred.
   /// @param data The data to be passed along with the transaction.

--- a/contracts/MyMultiSigExtended.sol
+++ b/contracts/MyMultiSigExtended.sol
@@ -421,7 +421,8 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
       sel == bytes4(keccak256('setGuard(address)')) ||
       sel == bytes4(keccak256('setAllowedTarget(address,bool)')) ||
       sel == bytes4(keccak256('disableAllowlist()')) ||
-      sel == bytes4(keccak256('setDailySpendingLimit(address,uint256)'));
+      sel == bytes4(keccak256('setDailySpendingLimit(address,uint256)')) ||
+      sel == bytes4(keccak256('setRequireTxSuccess(bool)'));
   }
 
   /// @notice Returns the unix timestamp a scheduled tx is ready to execute at.
@@ -664,9 +665,11 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   /// @dev    Signed over the dedicated `AllowanceTransaction` typehash bound
   ///         to `(to, value, data, gas, nonce = allowanceNonce(),
   ///         validUntil)`. Bumps `_allowanceNonce` once the signature
-  ///         validates, so each signature is single-use — even when the
-  ///         inner call fails — while the wallet's main `nonce()` (and any
-  ///         pending threshold-signed transaction) is untouched.
+  ///         validates, so each signature is single-use — including when the
+  ///         inner call fails silently — while the wallet's main `nonce()`
+  ///         (and any pending threshold-signed transaction) is untouched.
+  ///         A payload-carrying inner revert rolls the whole call (and the
+  ///         bump) back, matching `execTransaction`'s failure policy.
   ///         Runs the full pre-exec gates: a spend at or above
   ///         `sensitiveValueThreshold` must go through the timelock like any
   ///         other transaction, and self-calls are rejected outright so the
@@ -705,9 +708,12 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   }
 
   /// @dev Shared tail for the timelock (`executeScheduled`) and allowance
-  ///      paths: run the inner call via the base `_rawCall`, bubble a
-  ///      payload-carrying revert, and emit the standard success / failure
-  ///      events (+ the silent post-exec guard hook on success). `txHash` is
+  ///      paths: run the inner call via the base `_rawCall`, then apply the
+  ///      wallet-wide failure policy (see `_execTransaction`): a
+  ///      payload-carrying revert bubbles up and rolls the whole call back,
+  ///      an empty failure reverts `TxSuccessRequired` when
+  ///      `requireTxSuccess()` is on and otherwise emits `TxFailure`
+  ///      (+ the silent post-exec guard hook on success). `txHash` is
   ///      the EIP-712 hash the transaction was signed over, forwarded to the
   ///      post-exec guard.
   function _runLoggedCall(
@@ -801,18 +807,24 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
   }
 
   /// @notice Module-driven entry point. Bypasses signature threshold (modules
-  ///         are operational plugins); guard + allowlist still apply.
+  ///         are operational plugins); guard + allowlist still apply, and the
+  ///         wallet-wide reentrancy guard blocks the inner call (or a
+  ///         misbehaving module) from reentering this entry point.
   /// @param operation 0 = CALL, 1 = DELEGATECALL. For DELEGATECALL, `to` MUST
   ///        equal `address(this)` so the module's code runs in the wallet's
   ///        storage context.
   /// @dev    Does NOT bump `_txnNonce` — pending owner-signed transactions
-  ///         remain valid after a module action.
+  ///         remain valid after a module action. Failure policy mirrors
+  ///         `execTransaction`: an inner failure WITH revert data bubbles its
+  ///         payload and reverts; a failure WITHOUT revert data reverts
+  ///         `TxSuccessRequired` when `requireTxSuccess()` is on, otherwise
+  ///         returns `success = false` and emits `ModuleTransactionExecuted`.
   function execTransactionFromModule(
     address to,
     uint256 value,
     bytes memory data,
     uint256 operation
-  ) public payable virtual returns (bool success) {
+  ) public payable virtual nonReentrant returns (bool success) {
     if (!_isModule[msg.sender]) revert NotAModule(msg.sender);
     if (operation > 1) revert InvalidModuleOperation(operation);
 
@@ -834,6 +846,8 @@ contract MyMultiSigExtended is MyMultiSig, IAccount {
       _guardAfterRawExecution(to, value, data, operation);
     } else if (returnData.length > 0) {
       _revertWith(returnData);
+    } else if (requireTxSuccess()) {
+      revert TxSuccessRequired();
     }
 
     emit ModuleTransactionExecuted(msg.sender, to, value, data, operation, success);

--- a/contracts/mocks/MockReentrantModule.sol
+++ b/contracts/mocks/MockReentrantModule.sol
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import '../MyMultiSigExtended.sol';
+
+/// @title MockReentrantModule
+/// @notice Test fixture: a hostile module whose inner call tries to reenter
+///         `execTransactionFromModule` while the wallet is already executing
+///         a module transaction, so tests can assert the wallet's
+///         reentrancy guard blocks the nested call.
+contract MockReentrantModule {
+  MyMultiSigExtended public immutable wallet;
+
+  constructor(MyMultiSigExtended wallet_) {
+    wallet = wallet_;
+  }
+
+  /// @notice Asks the wallet to CALL back into `reenter()` below. The outer
+  ///         `execTransactionFromModule` holds the wallet's reentrancy
+  ///         guard, so the nested attempt inside `reenter()` must revert —
+  ///         and the wallet bubbles that revert payload back out.
+  function attack() external {
+    wallet.execTransactionFromModule(address(this), 0, abi.encodeCall(this.reenter, ()), 0);
+  }
+
+  /// @notice Inner call executed by the wallet: attempts the nested
+  ///         `execTransactionFromModule`.
+  function reenter() external {
+    wallet.execTransactionFromModule(address(0xdead), 0, '', 0);
+  }
+
+  receive() external payable {}
+}

--- a/contracts/modules/SessionKeyModule.sol
+++ b/contracts/modules/SessionKeyModule.sol
@@ -184,7 +184,9 @@ contract SessionKeyModule is ReentrancyGuard {
   ///         charged before the call and refunded if the inner call
   ///         fails, so a reentrant attempt can never overspend.
   /// @return success Whether the inner call succeeded. Reverts with a
-  ///         payload are bubbled up by the wallet instead.
+  ///         payload — and, when the wallet's `requireTxSuccess()` is on,
+  ///         silent failures too — are bubbled up by the wallet instead of
+  ///         returning `false`.
   function executeWithSessionKey(
     address wallet,
     address to,

--- a/contracts/test/MyMultiSigExtended.moduleGuard.t.sol
+++ b/contracts/test/MyMultiSigExtended.moduleGuard.t.sol
@@ -1,0 +1,115 @@
+// SPDX-License-Identifier: MIT
+pragma solidity 0.8.24;
+
+import { Helper } from './shared/helper.t.sol';
+import { MyMultiSigExtended } from '../MyMultiSigExtended.sol';
+import { MockModule } from '../mocks/MockModule.sol';
+import { MockReentrantModule } from '../mocks/MockReentrantModule.sol';
+
+/// @title Module entry-point hardening tests
+/// @notice Wallet-side protections of `execTransactionFromModule`: the
+///         reentrancy guard, the `requireTxSuccess()` failure policy, and
+///         the sensitive-selector registration of `setRequireTxSuccess`.
+contract MyMultiSigExtendedModuleGuardTest is Helper {
+  MockModule internal module;
+  MockReentrantModule internal reentrantModule;
+
+  /// @dev Gas forwarded to the inner call of wallet-driven execs — admin
+  ///      setters write cold storage slots, so this needs more than the
+  ///      suite-wide `DEFAULT_GAS`.
+  uint256 internal constant EXEC_GAS = 300_000;
+
+  event ModuleTransactionExecuted(
+    address indexed module,
+    address indexed to,
+    uint256 indexed value,
+    bytes data,
+    uint256 operation,
+    bool success
+  );
+
+  function setUp() public {
+    initialize_helper(LOG_LEVEL, TestType.TestWithoutFactory_extended);
+    module = new MockModule(myMultiSigExtended);
+    reentrantModule = new MockReentrantModule(myMultiSigExtended);
+    _execFromWallet(abi.encodeWithSignature('enableModule(address)', address(module)));
+    _execFromWallet(abi.encodeWithSignature('enableModule(address)', address(reentrantModule)));
+    assertTrue(myMultiSigExtended.isModule(address(module)));
+    assertTrue(myMultiSigExtended.isModule(address(reentrantModule)));
+  }
+
+  function _ownersPk() internal view returns (uint256[] memory pks) {
+    pks = new uint256[](2);
+    pks[0] = OWNERS_PK[0];
+    pks[1] = OWNERS_PK[1];
+  }
+
+  /// @dev Threshold-signed `execTransaction` from the wallet to itself.
+  function _execFromWallet(bytes memory data_) internal {
+    address to_ = address(myMultiSig);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      to_,
+      0,
+      data_,
+      EXEC_GAS,
+      build_signatures(myMultiSig, _ownersPk(), to_, 0, data_, EXEC_GAS)
+    );
+  }
+
+  // ---------- reentrancy ----------
+
+  function test_module_reentrancy_is_blocked() public {
+    // The nested `execTransactionFromModule` inside `reenter()` hits the
+    // wallet's reentrancy guard; the guard's revert payload bubbles back
+    // out through the outer module call.
+    vm.expectRevert('ReentrancyGuard: reentrant call');
+    reentrantModule.attack();
+  }
+
+  // ---------- requireTxSuccess on the module path ----------
+
+  function test_module_silent_failure_returns_false_by_default() public {
+    // Sending more than the wallet's balance fails without returndata →
+    // soft failure: the module call completes and reports success = false.
+    uint256 value = address(myMultiSig).balance + 1;
+    vm.expectEmit(true, true, true, true);
+    emit ModuleTransactionExecuted(address(module), NOT_OWNERS[0], value, '', 0, false);
+    module.execCall(NOT_OWNERS[0], value, '');
+  }
+
+  function test_module_silent_failure_reverts_when_requireTxSuccess_on() public {
+    _execFromWallet(abi.encodeWithSignature('setRequireTxSuccess(bool)', true));
+    assertTrue(myMultiSig.requireTxSuccess());
+    uint256 value = address(myMultiSig).balance + 1;
+    vm.expectRevert(abi.encodeWithSignature('TxSuccessRequired()'));
+    module.execCall(NOT_OWNERS[0], value, '');
+  }
+
+  // ---------- setRequireTxSuccess is timelock-sensitive ----------
+
+  function test_setRequireTxSuccess_is_default_sensitive() public {
+    assertTrue(myMultiSigExtended.isSensitiveSelector(bytes4(keccak256('setRequireTxSuccess(bool)'))));
+  }
+
+  function test_setRequireTxSuccess_requires_timelock_when_enabled() public {
+    _execFromWallet(abi.encodeWithSignature('setTimelockDelay(uint256)', uint256(60)));
+    assertEq(myMultiSigExtended.timelockDelay(), 60);
+
+    bytes memory data = abi.encodeWithSignature('setRequireTxSuccess(bool)', true);
+    bytes memory signatures = build_signatures(myMultiSig, _ownersPk(), address(myMultiSig), 0, data, EXEC_GAS);
+    uint96 nonceBefore = myMultiSig.nonce();
+    vm.prank(OWNERS[0]);
+    vm.expectRevert(
+      abi.encodeWithSelector(
+        MyMultiSigExtended.SensitiveCallRequiresDelay.selector,
+        address(myMultiSig),
+        bytes4(keccak256('setRequireTxSuccess(bool)')),
+        uint256(0)
+      )
+    );
+    myMultiSigExtended.execTransaction(address(myMultiSig), 0, data, EXEC_GAS, nonceBefore, 0, 0, signatures);
+    assertFalse(myMultiSig.requireTxSuccess());
+  }
+}

--- a/contracts/test/shared/tests.t.sol
+++ b/contracts/test/shared/tests.t.sol
@@ -794,6 +794,41 @@ abstract contract TestBasic is Helper {
     assertEq(myMultiSig.nonce(), nonceBefore);
   }
 
+  function testMyMultiSig_requireTxSuccess_payloadRevertBubblesInnerError() public {
+    // Enable the flag through a threshold-signed self-call.
+    address to = address(myMultiSig);
+    bytes memory enableData = abi.encodeWithSignature('setRequireTxSuccess(bool)', true);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      to,
+      0,
+      enableData,
+      DEFAULT_GAS,
+      build_signatures(myMultiSig, OWNERS_PK, to, 0, enableData, DEFAULT_GAS)
+    );
+    assertTrue(myMultiSig.requireTxSuccess());
+
+    // An inner call that reverts WITH a payload bubbles that payload — not
+    // `TxSuccessRequired` — and preserves the nonce, so the failure policy
+    // for payload-carrying reverts is identical whichever way the flag is set.
+    uint96 nonceBefore = myMultiSig.nonce();
+    bytes memory data = build_removeOwner(NOT_OWNERS[0]);
+    bytes memory signatures = build_signatures(myMultiSig, OWNERS_PK, to, 0, data, DEFAULT_GAS);
+    help_execTransaction(
+      myMultiSig,
+      OWNERS[0],
+      to,
+      0,
+      data,
+      DEFAULT_GAS,
+      signatures,
+      nonceBefore,
+      Errors.RevertStatus.OwnerToRemoveMustBeOwner
+    );
+    assertEq(myMultiSig.nonce(), nonceBefore);
+  }
+
   // ---------------------------------------------------------------------
   // approval pruning after execution
   // ---------------------------------------------------------------------

--- a/test/shared/tests.ts
+++ b/test/shared/tests.ts
@@ -1328,6 +1328,38 @@ export async function MyMultiSigStandardTests(deploymentType = DeploymentType.Si
         )
         expect(await contract.nonce()).to.equal(nonceBefore)
       })
+
+      it('an inner revert with a payload bubbles and preserves the nonce even when enabled', async function () {
+        const enableData = contract.interface.encodeFunctionData('setRequireTxSuccess', [true]) as `0x${string}`
+        await Helper.execTransaction(
+          contract,
+          owner01,
+          [owner01, owner02, owner03],
+          contract.address,
+          Helper.ZERO,
+          enableData,
+          Helper.DEFAULT_GAS,
+        )
+        expect(await contract.requireTxSuccess()).to.be.true
+
+        // removeOwner(non-owner) reverts WITH a payload: the payload must
+        // bubble — not TxSuccessRequired — and the nonce stays put, so
+        // payload-carrying failures behave identically whichever way the
+        // flag is set.
+        const nonceBefore = await contract.nonce()
+        const data = contract.interface.encodeFunctionData('removeOwner', [user01.address]) as `0x${string}`
+        await Helper.execTransaction(
+          contract,
+          owner01,
+          [owner01, owner02, owner03],
+          contract.address,
+          Helper.ZERO,
+          data,
+          Helper.DEFAULT_GAS,
+          Helper.errors.OWNER_TO_REMOVE_MUST_BE_OWNER,
+        )
+        expect(await contract.nonce()).to.equal(nonceBefore)
+      })
     })
 
     describe('approval pruning after execution', function () {
@@ -3050,6 +3082,7 @@ export async function MyMultiSigAdvancedTests(deploymentType = DeploymentType.Si
           'setDailySpendingLimit(address,uint256)',
           'setSensitiveSelector(bytes4,bool)',
           'setSensitiveValueThreshold(uint256)',
+          'setRequireTxSuccess(bool)',
         ]
         for (const fragment of sensitiveFragments) {
           const selector = ethers.utils.id(fragment).slice(0, 10)
@@ -3069,6 +3102,7 @@ export async function MyMultiSigAdvancedTests(deploymentType = DeploymentType.Si
           ]),
           contract.interface.encodeFunctionData('setSensitiveSelector(bytes4,bool)', ['0x12345678', false]),
           contract.interface.encodeFunctionData('setSensitiveValueThreshold(uint256)', [ethers.utils.parseEther('1')]),
+          contract.interface.encodeFunctionData('setRequireTxSuccess(bool)', [true]),
         ]
         for (const data of sensitiveCalls) {
           await Helper.execTransaction(
@@ -3087,6 +3121,7 @@ export async function MyMultiSigAdvancedTests(deploymentType = DeploymentType.Si
         expect(await contract.allowedTargetsEnabled()).to.be.false
         expect(await contract.dailySpendingLimit(owner01.address)).to.be.equal(0)
         expect(await contract.sensitiveValueThreshold()).to.be.equal(0)
+        expect(await contract.requireTxSuccess()).to.be.false
       })
 
       it('protection setters remain reachable through schedule + executeScheduled', async function () {
@@ -3580,6 +3615,49 @@ export async function MyMultiSigAdvancedTests(deploymentType = DeploymentType.Si
         await expect(
           contract.connect(owner01).execTransactionFromModule(user01.address, 0, '0x', 0),
         ).to.be.revertedWithCustomError(contract, 'NotAModule')
+      })
+
+      it('execTransactionFromModule cannot be reentered', async function () {
+        const Module = await ethers.getContractFactory('MockReentrantModule')
+        const module = await Module.deploy(contract.address)
+        await module.deployed()
+        await Helper.enableModule(contract, owner01, [owner01, owner02], module.address)
+        // The nested execTransactionFromModule inside the module's inner
+        // call hits the wallet's reentrancy guard; the guard's revert
+        // payload bubbles back out of the outer module call.
+        await expect(module.attack()).to.be.revertedWith('ReentrancyGuard: reentrant call')
+      })
+
+      it('a silent module-call failure honors requireTxSuccess', async function () {
+        const Module = await ethers.getContractFactory('MockModule')
+        const module = await Module.deploy(contract.address)
+        await module.deployed()
+        await Helper.enableModule(contract, owner01, [owner01, owner02], module.address)
+
+        // Soft by default: sending more than the wallet's balance fails
+        // without returndata and the module call reports success = false.
+        const value = (await ethers.provider.getBalance(contract.address)).add(1)
+        await expect(module.execCall(user01.address, value, '0x'))
+          .to.emit(contract, 'ModuleTransactionExecuted')
+          .withArgs(module.address, user01.address, value, '0x', 0, false)
+
+        const enableData = contract.interface.encodeFunctionData('setRequireTxSuccess', [true]) as `0x${string}`
+        await Helper.execTransaction(
+          contract,
+          owner01,
+          [owner01, owner02],
+          contract.address,
+          Helper.ZERO,
+          enableData,
+          Helper.DEFAULT_GAS,
+        )
+        expect(await contract.requireTxSuccess()).to.be.true
+        // Must-succeed mode: the same silent failure now reverts the module
+        // call with TxSuccessRequired.
+        await expect(module.execCall(user01.address, value, '0x')).to.be.revertedWithCustomError(
+          contract,
+          'TxSuccessRequired',
+        )
       })
     })
 


### PR DESCRIPTION
## Summary

- `execTransactionFromModule` is now `nonReentrant`, so a module's inner call (or a misbehaving module) cannot reenter the module entry point, and a silent inner failure now honors `requireTxSuccess()` by reverting `TxSuccessRequired` instead of only returning `success = false`.
- `setRequireTxSuccess(bool)` joins the default sensitive-selector set, so once a timelock delay is configured the toggle must go through `scheduleTransaction`.
- NatSpec across `MyMultiSig`, `MyMultiSigExtended` and `SessionKeyModule` now spells out the wallet-wide inner-call failure policy: a failure WITH revert data always bubbles its payload and preserves the nonce; `requireTxSuccess()` only governs failures WITHOUT revert data (revert `TxSuccessRequired` when on, soft `TxFailure` + nonce consumption when off).

## Tests

- New Foundry suite `contracts/test/MyMultiSigExtended.moduleGuard.t.sol` + `MockReentrantModule` fixture: reentrancy is blocked, silent module failures honor `requireTxSuccess`, and the selector is sensitive by default and timelock-gated once a delay is set.
- Mirrored Hardhat cases in `test/shared/tests.ts`, plus payload-bubbling coverage in both shared suites. Silent failures are provoked by sending more than the wallet's balance so the tests hold on funded fixtures.
- `forge test`: 199 passed. `npx hardhat test`: 372 passed.

No ABI changes — committed `types/` and `constants/` are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)